### PR TITLE
feat: allow to fetch logged in profile data

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
+++ b/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
@@ -1,11 +1,15 @@
 package com.getcapacitor.community.facebooklogin;
 
 import android.content.Intent;
+import android.os.Bundle;
 import android.util.Log;
 import com.facebook.AccessToken;
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
+import com.facebook.FacebookRequestError;
+import com.facebook.GraphRequest;
+import com.facebook.GraphResponse;
 import com.facebook.login.LoginManager;
 import com.facebook.login.LoginResult;
 import com.getcapacitor.JSArray;
@@ -20,6 +24,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 @NativePlugin(requestCodes = { FacebookLogin.FACEBOOK_SDK_REQUEST_CODE_OFFSET })
 public class FacebookLogin extends Plugin {
@@ -204,5 +210,65 @@ public class FacebookLogin extends Plugin {
         }
 
         call.success(ret);
+    }
+
+    @PluginMethod
+    public void getProfile(final PluginCall call) {
+        Log.d(getLogTag(), "Entering getProfile()");
+
+        AccessToken accessToken = AccessToken.getCurrentAccessToken();
+
+        JSObject ret = new JSObject();
+
+        if (accessToken == null) {
+            Log.d(getLogTag(), "getProfile: accessToken is null");
+            call.error("You're not logged in. Call FacebookLogin.login() first to obtain an access token.");
+
+            return;
+        }
+
+        if (accessToken.isExpired()) {
+            Log.d(getLogTag(), "getProfile: accessToken is expired");
+            call.error("AccessToken is expired.");
+
+            return;
+        }
+
+        JSArray fields = call.getArray("fields");
+        Bundle parameters = new Bundle();
+        try {
+            parameters.putString("fields", fields.join(","));
+        } catch (JSONException e) {
+            call.error("Can't handle fields", e);
+        }
+
+        GraphRequest graphRequest = GraphRequest.newMeRequest(
+            accessToken,
+            new GraphRequest.GraphJSONObjectCallback() {
+
+                @Override
+                public void onCompleted(JSONObject object, GraphResponse response) {
+                    FacebookRequestError requestError = response.getError();
+
+                    if (requestError != null) {
+                        call.error(requestError.getErrorMessage());
+
+                        return;
+                    }
+
+                    try {
+                        JSONObject jsonObject = response.getJSONObject();
+                        JSObject jsObject = JSObject.fromJSONObject(jsonObject);
+
+                        call.success(jsObject);
+                    } catch (JSONException e) {
+                        call.error("Can't create response", e);
+                    }
+                }
+            }
+        );
+
+        graphRequest.setParameters(parameters);
+        graphRequest.executeAsync();
     }
 }

--- a/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
+++ b/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
@@ -2,6 +2,7 @@ package com.getcapacitor.community.facebooklogin;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.util.Log;
 import com.facebook.AccessToken;
 import com.facebook.CallbackManager;
@@ -218,8 +219,6 @@ public class FacebookLogin extends Plugin {
 
         AccessToken accessToken = AccessToken.getCurrentAccessToken();
 
-        JSObject ret = new JSObject();
-
         if (accessToken == null) {
             Log.d(getLogTag(), "getProfile: accessToken is null");
             call.error("You're not logged in. Call FacebookLogin.login() first to obtain an access token.");
@@ -234,10 +233,13 @@ public class FacebookLogin extends Plugin {
             return;
         }
 
-        JSArray fields = call.getArray("fields");
         Bundle parameters = new Bundle();
+
         try {
-            parameters.putString("fields", fields.join(","));
+            JSArray fields = call.getArray("fields");
+            String fieldsString = TextUtils.join(",", fields.toList());
+
+            parameters.putString("fields", fieldsString);
         } catch (JSONException e) {
             call.error("Can't handle fields", e);
 

--- a/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
+++ b/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
@@ -240,6 +240,8 @@ public class FacebookLogin extends Plugin {
             parameters.putString("fields", fields.join(","));
         } catch (JSONException e) {
             call.error("Can't handle fields", e);
+
+            return;
         }
 
         GraphRequest graphRequest = GraphRequest.newMeRequest(

--- a/ios/Plugin.xcodeproj/project.pbxproj
+++ b/ios/Plugin.xcodeproj/project.pbxproj
@@ -284,11 +284,19 @@
 				"${PODS_ROOT}/Target Support Files/Pods-PluginTests/Pods-PluginTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Capacitor/Capacitor.framework",
 				"${BUILT_PRODUCTS_DIR}/CapacitorCordova/Cordova.framework",
+				"${BUILT_PRODUCTS_DIR}/FBSDKCoreKit/FBSDKCoreKit.framework",
+				"${BUILT_PRODUCTS_DIR}/FBSDKLoginKit/FBSDKLoginKit.framework",
+				"${BUILT_PRODUCTS_DIR}/FacebookCore/FacebookCore.framework",
+				"${BUILT_PRODUCTS_DIR}/FacebookLogin/FacebookLogin.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Capacitor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Cordova.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKCoreKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKLoginKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FacebookCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FacebookLogin.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Plugin.xcodeproj/project.pbxproj
+++ b/ios/Plugin.xcodeproj/project.pbxproj
@@ -284,19 +284,11 @@
 				"${PODS_ROOT}/Target Support Files/Pods-PluginTests/Pods-PluginTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Capacitor/Capacitor.framework",
 				"${BUILT_PRODUCTS_DIR}/CapacitorCordova/Cordova.framework",
-				"${BUILT_PRODUCTS_DIR}/FBSDKCoreKit/FBSDKCoreKit.framework",
-				"${BUILT_PRODUCTS_DIR}/FBSDKLoginKit/FBSDKLoginKit.framework",
-				"${BUILT_PRODUCTS_DIR}/FacebookCore/FacebookCore.framework",
-				"${BUILT_PRODUCTS_DIR}/FacebookLogin/FacebookLogin.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Capacitor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Cordova.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKCoreKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKLoginKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FacebookCore.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FacebookLogin.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -7,5 +7,5 @@ CAP_PLUGIN(FacebookLogin, "FacebookLogin",
            CAP_PLUGIN_METHOD(login, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(logout, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getCurrentAccessToken, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHID(getProfile, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getProfile, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -7,4 +7,5 @@ CAP_PLUGIN(FacebookLogin, "FacebookLogin",
            CAP_PLUGIN_METHOD(login, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(logout, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getCurrentAccessToken, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHID(getProfile, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -78,32 +78,32 @@ public class FacebookLogin: CAPPlugin {
 
         call.success([ "accessToken": accessTokenToJson(accessToken) ])
     }
-  
+
     @objc func getProfile(_ call: CAPPluginCall) {
         guard let accessToken = AccessToken.current else {
-            call.error("You're not logged in. Call FacebookLogin.login() first to obtain an access token.");
-            return;
+            call.error("You're not logged in. Call FacebookLogin.login() first to obtain an access token.")
+            return
         }
 
-        if (accessToken.isExpired) {
-            call.error("AccessToken is expired.");
-            return;
+        if accessToken.isExpired {
+            call.error("AccessToken is expired.")
+            return
         }
 
         guard let fields = call.getArray("fields", String.self) else {
-            call.error("Missing fields argument");
-            return;
+            call.error("Missing fields argument")
+            return
         }
-        let parameters = ["fields": fields.joined(separator: ",")];
-        let graphRequest = GraphRequest.init(graphPath: "me", parameters: parameters);
+        let parameters = ["fields": fields.joined(separator: ",")]
+        let graphRequest = GraphRequest.init(graphPath: "me", parameters: parameters)
 
         graphRequest.start { (_ connection, _ result, _ error) in
-            if (error != nil) {
-                call.error("An error has been occured.", error);
-                return;
+            if error != nil {
+                call.error("An error has been occured.", error)
+                return
             }
 
-            call.success(result as! [String: Any]);
+            call.success(result as! [String: Any])
         }
     }
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -78,4 +78,29 @@ public class FacebookLogin: CAPPlugin {
 
         call.success([ "accessToken": accessTokenToJson(accessToken) ])
     }
+  
+  @objc func getProfile(_ call: CAPPluginCall) {
+      guard let accessToken = AccessToken.current else {
+          call.error("You're not logged in. Call FacebookLogin.login() first to obtain an access token.");
+          return;
+      }
+    
+      if (accessToken.isExpired) {
+          call.error("AccessToken is expired.");
+          return;
+      }
+      
+      let fields = call.getArray("fields", String.self, defaultUserFields)!;
+      let parameters = ["fields": fields.joined(separator: ",")];
+      let graphRequest = GraphRequest.init(graphPath: "me", parameters: parameters);
+      
+      graphRequest.start { (_ connection, _ result, _ error) in
+          if (error != nil) {
+            call.error("An error has been occured.", error);
+            return;
+          }
+          
+          call.success(result as! [String: Any]);
+      }
+  }
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -79,28 +79,28 @@ public class FacebookLogin: CAPPlugin {
         call.success([ "accessToken": accessTokenToJson(accessToken) ])
     }
   
-  @objc func getProfile(_ call: CAPPluginCall) {
-      guard let accessToken = AccessToken.current else {
-          call.error("You're not logged in. Call FacebookLogin.login() first to obtain an access token.");
-          return;
-      }
-    
-      if (accessToken.isExpired) {
-          call.error("AccessToken is expired.");
-          return;
-      }
-      
-      let fields = call.getArray("fields", String.self, defaultUserFields)!;
-      let parameters = ["fields": fields.joined(separator: ",")];
-      let graphRequest = GraphRequest.init(graphPath: "me", parameters: parameters);
-      
-      graphRequest.start { (_ connection, _ result, _ error) in
-          if (error != nil) {
-            call.error("An error has been occured.", error);
+    @objc func getProfile(_ call: CAPPluginCall) {
+        guard let accessToken = AccessToken.current else {
+            call.error("You're not logged in. Call FacebookLogin.login() first to obtain an access token.");
             return;
-          }
-          
-          call.success(result as! [String: Any]);
-      }
-  }
+        }
+
+        if (accessToken.isExpired) {
+            call.error("AccessToken is expired.");
+            return;
+        }
+
+        let fields = call.getArray("fields", String.self, defaultUserFields)!;
+        let parameters = ["fields": fields.joined(separator: ",")];
+        let graphRequest = GraphRequest.init(graphPath: "me", parameters: parameters);
+
+        graphRequest.start { (_ connection, _ result, _ error) in
+            if (error != nil) {
+                call.error("An error has been occured.", error);
+                return;
+            }
+
+            call.success(result as! [String: Any]);
+        }
+    }
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -90,7 +90,10 @@ public class FacebookLogin: CAPPlugin {
             return;
         }
 
-        let fields = call.getArray("fields", String.self, defaultUserFields)!;
+        guard let fields = call.getArray("fields", String.self) else {
+            call.error("Missing fields argument");
+            return;
+        }
         let parameters = ["fields": fields.joined(separator: ",")];
         let graphRequest = GraphRequest.init(graphPath: "me", parameters: parameters);
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -30,6 +30,6 @@ export interface FacebookLoginPlugin {
   logout(): Promise<void>;
   getCurrentAccessToken(): Promise<FacebookCurrentAccessTokenResponse>;
   getProfile<T extends object>(options: {
-    requiredFields: readonly string[];
+    fields: readonly string[];
   }): Promise<T>;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -29,5 +29,7 @@ export interface FacebookLoginPlugin {
   login(options: { permissions: string[] }): Promise<FacebookLoginResponse>;
   logout(): Promise<void>;
   getCurrentAccessToken(): Promise<FacebookCurrentAccessTokenResponse>;
-  getProfile<T extends object>(requiredFields: readonly string[]): Promise<T>;
+  getProfile<T extends object>(options: {
+    requiredFields: readonly string[];
+  }): Promise<T>;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -29,4 +29,5 @@ export interface FacebookLoginPlugin {
   login(options: { permissions: string[] }): Promise<FacebookLoginResponse>;
   logout(): Promise<void>;
   getCurrentAccessToken(): Promise<FacebookCurrentAccessTokenResponse>;
+  getProfile<T extends object>(requiredFields: readonly string[]): Promise<T>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -137,10 +137,10 @@ export class FacebookLoginWeb extends WebPlugin implements FacebookLoginPlugin {
     );
   }
 
-  async getProfile<T extends object>(
-    requiredFields: readonly string[],
-  ): Promise<T> {
-    const fields = requiredFields.join(',');
+  async getProfile<T extends object>(options: {
+    requiredFields: readonly string[];
+  }): Promise<T> {
+    const fields = options.requiredFields.join(',');
 
     return new Promise<T>((resolve, reject) => {
       FB.api<{ fields: string }, FacebookGetProfileResponse>(

--- a/src/web.ts
+++ b/src/web.ts
@@ -138,9 +138,9 @@ export class FacebookLoginWeb extends WebPlugin implements FacebookLoginPlugin {
   }
 
   async getProfile<T extends object>(options: {
-    requiredFields: readonly string[];
+    fields: readonly string[];
   }): Promise<T> {
-    const fields = options.requiredFields.join(',');
+    const fields = options.fields.join(',');
 
     return new Promise<T>((resolve, reject) => {
       FB.api<{ fields: string }, FacebookGetProfileResponse>(


### PR DESCRIPTION
Any suggestions and improvements are welcome since it is my first meeting with the native part.
I didn't update an example project since I checked Android and iOS on my project via the symlink, since it already configured.

The PR adds the method called `getProfile` with utilizes the current access token to send the Graph API request via FB SDK to retrieve information about the connected user.

It closes #23.