### PR TITLE
Update android plugin call method in MainActivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,7 @@ public class MainActivity extends BridgeActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Initializes the Bridge
-        this.init(savedInstanceState, new ArrayList<Class<? extends Plugin>>() {{
-            // Additional plugins you've installed go here
-            // Ex: add(TotallyAwesomePlugin.class);
-            add(com.getcapacitor.community.facebooklogin.FacebookLogin.class);
-        }});
+        registerPlugin(com.getcapacitor.community.facebooklogin.FacebookLogin.class);
     }
 }
 ```


### PR DESCRIPTION
From capacitor3 docs https://capacitorjs.com/docs/v3/updating/3-0#switch-to-automatic-android-plugin-loading 
this.init(savedInstanceState, new ArrayList<Class<? extends Plugin>>() has been removed