### PR TITLE
fix: use registerPlugin function (remove deprecated func call)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,23 +83,30 @@
       }
     },
     "@capacitor/android": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-2.4.6.tgz",
-      "integrity": "sha512-SBXO0eVtkssnq1gfs6n/8vJLJXPjzqbIblhPetMiR0Myvjt9eqB7v5HbQ4t1EW0+jV46UGyFV6CPCrZeKPtvXg==",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-3.0.0-beta.3.tgz",
+      "integrity": "sha512-wHaRK2O9J1YhIxb4JD2uNbQ84Fq5qGMW0+eadBxBB81OIV9MX+7MEqmIyCUHfu8SMegDYCk1uBiB9mJxkxdImg==",
       "dev": true
     },
     "@capacitor/core": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-2.4.6.tgz",
-      "integrity": "sha512-3KLSMorCELA5RNRXwHOGlRGuxXaxCEYHC29wOUxObicI2mf14hbMJWylt4QBzNmSqh3/ha7u4/CAZMoJUQR/QA==",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.0.0-beta.3.tgz",
+      "integrity": "sha512-RhNmwj5ERMUNQKdK1xXC9d3jhQ2IrBUAn8NMvWUOS/dR+wWyUjmwFFk6jRYaJQuxQOHWoffjIjSmefldyKqR+g==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
       }
     },
     "@capacitor/ios": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-2.4.6.tgz",
-      "integrity": "sha512-/IMmgVUgQgMm1Yv5CaWhZ9UTkVh5GFDX1vFZOB0bMu5v5jkolO/9SLyjbqogDNE2EIl9GuH6RSqZaOh2Xu2Ebg==",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-3.0.0-beta.3.tgz",
+      "integrity": "sha512-4MKs/h0exw2hPYa58p/kIlUqI7Ug64eZ/j1HpbCCalonx2JJbRQThT7K0jtUrFbySHToMPGf84SK6m7oWEW9hQ==",
       "dev": true
     },
     "@ionic/prettier-config": {
@@ -3577,7 +3584,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.11.0",
@@ -3595,9 +3603,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
+      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
       "dev": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
   "author": "Masahiko Sakakibara <sakakibara@rdlabo.jp>",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "^2.0.0"
+    "@capacitor/core": "^3.0.0-beta.3"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",
   "devDependencies": {
-    "@capacitor/android": "^2.0.0",
-    "@capacitor/ios": "^2.0.0",
+    "@capacitor/android": "^3.0.0-beta.3",
+    "@capacitor/ios": "^3.0.0-beta.3",
     "@ionic/prettier-config": "^1.0.0",
     "@ionic/swiftlint-config": "^1.0.2",
     "husky": "^4.2.5",
@@ -34,7 +34,7 @@
     "pretty-quick": "^2.0.1",
     "rimraf": "^3.0.0",
     "swiftlint": "^1.0.1",
-    "typescript": "^3.2.4"
+    "typescript": "^4.2.2"
   },
   "husky": {
     "hooks": {

--- a/src/web.ts
+++ b/src/web.ts
@@ -160,9 +160,9 @@ export class FacebookLoginWeb extends WebPlugin implements FacebookLoginPlugin {
   }
 }
 
-const FacebookLogin = new FacebookLoginWeb();
-
+import { registerPlugin } from '@capacitor/core';
+const FacebookLogin = registerPlugin<FacebookLoginPlugin>('FacebookLogin', {
+  web: new FacebookLoginWeb(),
+});
 export { FacebookLogin };
 
-import { registerWebPlugin } from '@capacitor/core';
-registerWebPlugin(FacebookLogin);


### PR DESCRIPTION
issue #36 

It might be breaking changes for capacitor 2.x plugin user.

