### PR TITLE
Added initialization method for Capacitor Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,24 +160,11 @@ More information can be found here: https://developers.facebook.com/docs/faceboo
 
 ### Web configuration
 
-```javascript
-window.fbAsyncInit = function() {
-  FB.init({
-    appId: '[APP_ID]',
-    cookie: true, // enable cookies to allow the server to access the session
-    xfbml: true, // parse social plugins on this page
-    version: 'v5.0' // use graph api current version
-  });
-};
+```typescript
+import {FacebookLogin} from "@capacitor-community/facebook-login";
 
-// Load the SDK asynchronously
-(function(d, s, id) {
-  var js, fjs = d.getElementsByTagName(s)[0];
-  if (d.getElementById(id)) return;
-  js = d.createElement(s); js.id = id;
-  js.src = "https://connect.facebook.net/en_US/sdk.js";
-  fjs.parentNode.insertBefore(js, fjs);
-}(document, 'script', 'facebook-jssdk'));
+// use hook after platform dom ready
+await FacebookLogin.initialize({appId: '105890006170720'});
 ```
 
 More information can be found here: https://developers.facebook.com/docs/facebook-login/web

--- a/demo/angular/src/app/app.component.ts
+++ b/demo/angular/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 import { Platform } from '@ionic/angular';
 import { SplashScreen } from '@ionic-native/splash-screen/ngx';
 import { StatusBar } from '@ionic-native/status-bar/ngx';
+import { FacebookLogin } from "@capacitor-community/facebook-login";
 
 @Component({
   selector: 'app-root',
@@ -21,6 +22,7 @@ export class AppComponent {
     this.platform.ready().then(() => {
       this.statusBar.styleDefault();
       this.splashScreen.hide();
+      FacebookLogin.initialize({appId: '105890006170720'});
     });
   }
 }

--- a/demo/angular/src/index.html
+++ b/demo/angular/src/index.html
@@ -21,24 +21,4 @@
 <body>
   <app-root></app-root>
 </body>
-
-<script>
-  window.fbAsyncInit = function() {
-    FB.init({
-      appId: '105890006170720',
-      cookie: true, // enable cookies to allow the server to access the session
-      xfbml: true, // parse social plugins on this page
-      version: 'v2.8' // use graph api version 2.8
-    });
-  };
-
-  // Load the SDK asynchronously
-  (function(d, s, id) {
-    var js, fjs = d.getElementsByTagName(s)[0];
-    if (d.getElementById(id)) return;
-    js = d.createElement(s); js.id = id;
-    js.src = "https://connect.facebook.net/en_US/sdk.js";
-    fjs.parentNode.insertBefore(js, fjs);
-  }(document, 'script', 'facebook-jssdk'));
-</script>
 </html>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -20,6 +20,7 @@ export interface FacebookCurrentAccessTokenResponse {
 }
 
 export interface FacebookLoginPlugin {
+  initialize(options: Partial<FacebookConfiguration>): Promise<void>;
   login(options: { permissions: string[] }): Promise<FacebookLoginResponse>;
   logout(): Promise<void>;
   getCurrentAccessToken(): Promise<FacebookCurrentAccessTokenResponse>;
@@ -47,4 +48,12 @@ export interface FacebookError {
 
 export interface FacebookGetProfileResponse {
   error: FacebookError | null;
+}
+
+export interface FacebookConfiguration {
+  appId: string;
+  autoLogAppEvents: boolean;
+  xfbml: boolean;
+  version: string;
+  locale:string;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,16 +2,19 @@ import { WebPlugin } from '@capacitor/core';
 import {
   FacebookLoginPlugin,
   FacebookLoginResponse,
-  FacebookCurrentAccessTokenResponse, FacebookGetLoginStatusResponse, FacebookGetProfileResponse,
+  FacebookCurrentAccessTokenResponse,
+  FacebookGetLoginStatusResponse,
+  FacebookGetProfileResponse,
+  FacebookConfiguration,
 } from './definitions';
 
 declare interface Facebook {
-  init(options: {
+  init(options: Partial<{
     appId: string;
     autoLogAppEvents: boolean;
     xfbml: boolean;
     version: string;
-  }): void;
+  }>): void;
 
   login(handle: (response: any) => void, options?: { scope: string }): void;
 
@@ -50,7 +53,39 @@ export class FacebookLoginWeb extends WebPlugin implements FacebookLoginPlugin {
       platforms: ['web'],
     });
   }
+  
+  initialize(options:Partial<FacebookConfiguration>): Promise<void> {
+    const defaultOptions={version: 'v10.0'};
+    return new Promise((resolve, reject) => {
+      try {
+         return this.loadScript(options.locale).then(()=> {
+            FB.init({...defaultOptions,...options});
+            resolve();
+        });
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
 
+  private loadScript(locale:string|undefined):Promise<void> {
+    if (typeof document === 'undefined') {return Promise.resolve();}
+    const scriptId = 'fb';
+    const scriptEl = document?.getElementById(scriptId);
+    if (scriptEl) {return Promise.resolve();}
+
+    const head = document.getElementsByTagName('head')[0];
+    const script = document.createElement('script');
+    return new Promise<void>((resolve) => {
+      script.defer = true;
+      script.async = true;
+      script.id = scriptId;
+      script.onload = () => {resolve();};
+      script.src = `https://connect.facebook.net/${locale ?? 'en_US'}/sdk.js`;
+      head.appendChild(script);
+    });
+  }
+  
   async login(options: {
     permissions: string[];
   }): Promise<FacebookLoginResponse> {


### PR DESCRIPTION
As there was no initialization method for web, it was making the documentation confusing. Additional, suggested method needed to directly call `FB` script inside `index.html`, which in my opinion could be omitted by having the implementation in the Plugin itself. This makes both integration and documentation simpler for the users.
A similar approach has been taken by `CapacitorGoogleAuth` plugin by `CodetrixStudio`.

Please review the PR and suggest/improve if anything is needed.