### PR TITLE
fix: set web dialog for login behavior

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
+++ b/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
@@ -81,6 +81,8 @@ public class FacebookLogin extends Plugin {
         this.callbackManager = CallbackManager.Factory.create();
 
         LoginManager
+                .getInstance().setLoginBehavior(LoginBehavior.WEB_ONLY);
+        LoginManager
             .getInstance()
             .registerCallback(
                 callbackManager,


### PR DESCRIPTION
Fix this issue : https://github.com/capacitor-community/facebook-login/issues/83
(Login error when [Facebook application](https://play.google.com/store/apps/details?id=com.facebook.katana) installed on device)