### PR TITLE
Add Limited login to IOS devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,17 +198,21 @@ if (result.accessToken) {
 
 ### Login with Limited Tracking (IOS only)
 
+A successful login in Limited Login returns an `AuthenticationToken` instance instead of a `AccessToken`. This is a JSON web token (JWT) containing a signature, and other pieces of information. Your app should validate the token to make sure it is authentic.
+
+More information can be found here: https://developers.facebook.com/docs/facebook-login/limited-login/token/validating
+
 ```ts
-import { FacebookLogin, FacebookLoginResponse, } from '@capacitor-community/facebook-login';
+import { FacebookLogin, FacebookLimitedLoginResponse, } from '@capacitor-community/facebook-login';
 
 const FACEBOOK_PERMISSIONS = ['email', 'user_birthday', 'user_photos', 'user_gender'];
-const result = await (<FacebookLoginResponse>(
+const result = await (<FacebookLimitedLoginResponse>(
   FacebookLogin.loginWithLimitedTracking({ permissions: FACEBOOK_PERMISSIONS })
 ));
 
-if (result.accessToken) {
+if (result.authenticationToken) {
   // Login successful.
-  console.log(`Facebook access token is ${result.accessToken.token}`);
+  console.log(`Facebook authentication token is ${result.authenticationToken.token}`);
 }
 ```
 
@@ -386,10 +390,10 @@ getProfile<T extends object>(options: { fields: readonly string[]; }) => Promise
 
 #### AuthenticationToken
 
-| Prop         | Type                |
-| ------------ | ------------------- |
-| **`token`**  | <code>string</code> |
-| **`userId`** | <code>string</code> |
+| Prop         | Type                | Description |
+| ------------ | ------------------- | ----------- |
+| **`token`**  | <code>string</code> | JWT token   |
+| **`userId`** | <code>string</code> |             |
 
 
 #### FacebookCurrentAccessTokenResponse

--- a/README.md
+++ b/README.md
@@ -196,6 +196,22 @@ if (result.accessToken) {
 }
 ```
 
+### Login with Limited Tracking (IOS only)
+
+```ts
+import { FacebookLogin, FacebookLoginResponse, } from '@capacitor-community/facebook-login';
+
+const FACEBOOK_PERMISSIONS = ['email', 'user_birthday', 'user_photos', 'user_gender'];
+const result = await (<FacebookLoginResponse>(
+  FacebookLogin.loginWithLimitedTracking({ permissions: FACEBOOK_PERMISSIONS })
+));
+
+if (result.accessToken) {
+  // Login successful.
+  console.log(`Facebook access token is ${result.accessToken.token}`);
+}
+```
+
 ### Logout
 
 ```ts
@@ -234,6 +250,7 @@ console.log(`Facebook user's email is ${result.email}`);
 
 * [`initialize(...)`](#initialize)
 * [`login(...)`](#login)
+* [`loginWithLimitedTracking(...)`](#loginwithlimitedtracking)
 * [`logout()`](#logout)
 * [`getCurrentAccessToken()`](#getcurrentaccesstoken)
 * [`getProfile(...)`](#getprofile)
@@ -269,6 +286,21 @@ login(options: { permissions: string[]; }) => Promise<FacebookLoginResponse>
 | **`options`** | <code>{ permissions: string[]; }</code> |
 
 **Returns:** <code>Promise&lt;<a href="#facebookloginresponse">FacebookLoginResponse</a>&gt;</code>
+
+--------------------
+
+
+### loginWithLimitedTracking(...)
+
+```typescript
+loginWithLimitedTracking(options: { permissions: string[]; }) => Promise<FacebookLimitedLoginResponse>
+```
+
+| Param         | Type                                    |
+| ------------- | --------------------------------------- |
+| **`options`** | <code>{ permissions: string[]; }</code> |
+
+**Returns:** <code>Promise&lt;<a href="#facebooklimitedloginresponse">FacebookLimitedLoginResponse</a>&gt;</code>
 
 --------------------
 
@@ -345,6 +377,21 @@ getProfile<T extends object>(options: { fields: readonly string[]; }) => Promise
 | **`userId`**              | <code>string</code>   |
 
 
+#### FacebookLimitedLoginResponse
+
+| Prop                      | Type                                                                        |
+| ------------------------- | --------------------------------------------------------------------------- |
+| **`authenticationToken`** | <code><a href="#authenticationtoken">AuthenticationToken</a> \| null</code> |
+
+
+#### AuthenticationToken
+
+| Prop         | Type                |
+| ------------ | ------------------- |
+| **`token`**  | <code>string</code> |
+| **`userId`** | <code>string</code> |
+
+
 #### FacebookCurrentAccessTokenResponse
 
 | Prop              | Type                                                        |
@@ -359,8 +406,6 @@ getProfile<T extends object>(options: { fields: readonly string[]; }) => Promise
 
 Make all properties in T optional
 
-<code>{
- [P in keyof T]?: T[P];
- }</code>
+<code>{ [P in keyof T]?: T[P]; }</code>
 
 </docgen-api>

--- a/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
+++ b/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
@@ -191,6 +191,11 @@ public class FacebookLogin extends Plugin {
     }
 
     @PluginMethod
+    public void loginWithLimitedTracking(PluginCall call) {
+        call.unavailable("Not available in Android.");
+    }
+
+    @PluginMethod
     public void logout(PluginCall call) {
         Log.d(getLogTag(), "Entering logout()");
 

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -6,6 +6,7 @@
 CAP_PLUGIN(FacebookLogin, "FacebookLogin",
            CAP_PLUGIN_METHOD(initialize, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(login, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(loginWithLimitedTracking, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(logout, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getCurrentAccessToken, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getProfile, CAPPluginReturnPromise);

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -10,6 +10,7 @@ export interface AccessToken {
 }
 
 export interface AuthenticationToken {
+  /** JWT token */
   token: string;
   userId?: string;
 }
@@ -67,5 +68,5 @@ export interface FacebookConfiguration {
   autoLogAppEvents: boolean;
   xfbml: boolean;
   version: string;
-  locale:string;
+  locale: string;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -9,10 +9,19 @@ export interface AccessToken {
   userId?: string;
 }
 
+export interface AuthenticationToken {
+  token: string;
+  userId?: string;
+}
+
 export interface FacebookLoginResponse {
   accessToken: AccessToken | null;
   recentlyGrantedPermissions?: string[];
   recentlyDeniedPermissions?: string[];
+}
+
+export interface FacebookLimitedLoginResponse {
+  authenticationToken: AuthenticationToken | null;
 }
 
 export interface FacebookCurrentAccessTokenResponse {
@@ -22,6 +31,9 @@ export interface FacebookCurrentAccessTokenResponse {
 export interface FacebookLoginPlugin {
   initialize(options: Partial<FacebookConfiguration>): Promise<void>;
   login(options: { permissions: string[] }): Promise<FacebookLoginResponse>;
+  loginWithLimitedTracking(options: {
+    permissions: string[];
+  }): Promise<FacebookLimitedLoginResponse>;
   logout(): Promise<void>;
   getCurrentAccessToken(): Promise<FacebookCurrentAccessTokenResponse>;
   getProfile<T extends object>(options: {

--- a/src/web.ts
+++ b/src/web.ts
@@ -6,6 +6,7 @@ import {
   FacebookGetLoginStatusResponse,
   FacebookGetProfileResponse,
   FacebookConfiguration,
+  FacebookLimitedLoginResponse,
 } from './definitions';
 
 declare interface Facebook {
@@ -17,6 +18,11 @@ declare interface Facebook {
   }>): void;
 
   login(handle: (response: any) => void, options?: { scope: string }): void;
+
+  loginWithLimitedTracking(
+    handle: (response: any) => void,
+    options?: { scope: string },
+  ): void;
 
   logout(handle: (response: any) => void): void;
 
@@ -113,6 +119,12 @@ export class FacebookLoginWeb extends WebPlugin implements FacebookLoginPlugin {
         { scope: options.permissions.join(',') },
       );
     });
+  }
+
+  async loginWithLimitedTracking(_options: {
+    permissions: string[];
+  }): Promise<FacebookLimitedLoginResponse> {
+    throw new Error('Not available on Web');
   }
 
   async logout(): Promise<void> {


### PR DESCRIPTION
Facebook Login offers a Limited Login mode. When using the limited version of Facebook Login, the fact that a person used Facebook Login with this iOS app will not be used to personalize or measure advertising effectiveness. 

This PR adds a new `loginWithLimitedTracking()` method to request a limited login to facebook on IOS devices.

More info: https://developers.facebook.com/docs/facebook-login/limited-login