### PR TITLE
App Events Facebook #108

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ console.log(`Facebook user's email is ${result.email}`);
 * [`getCurrentAccessToken()`](#getcurrentaccesstoken)
 * [`getProfile(...)`](#getprofile)
 * [`logEvent(...)`](#logevent)
+* [`setAutoLogAppEventsEnabled(...)`](#setautologappeventsenabled)
+* [`setAdvertiserTrackingEnabled(...)`](#setadvertisertrackingenabled)
+* [`setAdvertiserIDCollectionEnabled(...)`](#setadvertiseridcollectionenabled)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 
@@ -357,12 +360,51 @@ getProfile<T extends object>(options: { fields: readonly string[]; }) => Promise
 ### logEvent(...)
 
 ```typescript
-logEvent(options: { eventName: string; }) => Promise<void>
+logEvent(options: { name: string; }) => Promise<void>
 ```
 
-| Param         | Type                                |
-| ------------- | ----------------------------------- |
-| **`options`** | <code>{ eventName: string; }</code> |
+| Param         | Type                           |
+| ------------- | ------------------------------ |
+| **`options`** | <code>{ name: string; }</code> |
+
+--------------------
+
+
+### setAutoLogAppEventsEnabled(...)
+
+```typescript
+setAutoLogAppEventsEnabled(options: { enabled: boolean; }) => Promise<void>
+```
+
+| Param         | Type                               |
+| ------------- | ---------------------------------- |
+| **`options`** | <code>{ enabled: boolean; }</code> |
+
+--------------------
+
+
+### setAdvertiserTrackingEnabled(...)
+
+```typescript
+setAdvertiserTrackingEnabled(options: { enabled: boolean; }) => Promise<void>
+```
+
+| Param         | Type                               |
+| ------------- | ---------------------------------- |
+| **`options`** | <code>{ enabled: boolean; }</code> |
+
+--------------------
+
+
+### setAdvertiserIDCollectionEnabled(...)
+
+```typescript
+setAdvertiserIDCollectionEnabled(options: { enabled: boolean; }) => Promise<void>
+```
+
+| Param         | Type                               |
+| ------------- | ---------------------------------- |
+| **`options`** | <code>{ enabled: boolean; }</code> |
 
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ console.log(`Facebook user's email is ${result.email}`);
 * [`reauthorize()`](#reauthorize)
 * [`getCurrentAccessToken()`](#getcurrentaccesstoken)
 * [`getProfile(...)`](#getprofile)
+* [`logEvent(...)`](#logevent)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 
@@ -349,6 +350,19 @@ getProfile<T extends object>(options: { fields: readonly string[]; }) => Promise
 | **`options`** | <code>{ fields: readonly string[]; }</code> |
 
 **Returns:** <code>Promise&lt;T&gt;</code>
+
+--------------------
+
+
+### logEvent(...)
+
+```typescript
+logEvent(options: { eventName: string; }) => Promise<void>
+```
+
+| Param         | Type                                |
+| ------------- | ----------------------------------- |
+| **`options`** | <code>{ eventName: string; }</code> |
 
 --------------------
 

--- a/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
+++ b/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
@@ -38,6 +38,7 @@ public class FacebookLogin extends Plugin {
     CallbackManager callbackManager;
 
     public static final int FACEBOOK_SDK_REQUEST_CODE_OFFSET = 0xface;
+    private AppEventsLogger logger;
 
     /**
      * Convert date to ISO 8601 format.
@@ -79,6 +80,7 @@ public class FacebookLogin extends Plugin {
         Log.d(getLogTag(), "Entering load()");
 
         this.callbackManager = CallbackManager.Factory.create();
+        this.logger = AppEventsLogger.newLogger(getContext());
 
         LoginManager
             .getInstance()
@@ -302,7 +304,6 @@ public class FacebookLogin extends Plugin {
     @PluginMethod
     public void logEvent(final PluginCall call) {
         Log.d(getLogTag(), "Entering logEvent()");
-        AppEventsLogger logger = AppEventsLogger.newLogger(this.getContext());
         String eventName = call.getString("eventName");
         if (eventName != null) {
             logger.logEvent(eventName);

--- a/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
+++ b/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
@@ -12,6 +12,7 @@ import com.facebook.FacebookRequestError;
 import com.facebook.FacebookSdk;
 import com.facebook.GraphRequest;
 import com.facebook.GraphResponse;
+import com.facebook.appevents.AppEventsLogger;
 import com.facebook.login.LoginManager;
 import com.facebook.login.LoginResult;
 import com.getcapacitor.JSArray;
@@ -296,5 +297,15 @@ public class FacebookLogin extends Plugin {
 
         graphRequest.setParameters(parameters);
         graphRequest.executeAsync();
+    }
+
+    @PluginMethod
+    public void logEvent(final PluginCall call) {
+        Log.d(getLogTag(), "Entering logEvent()");
+        AppEventsLogger logger = AppEventsLogger.newLogger(this.getContext());
+        String eventName = call.getString("eventName");
+        if (eventName != null) {
+            logger.logEvent(eventName);
+        }
     }
 }

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -10,4 +10,5 @@ CAP_PLUGIN(FacebookLogin, "FacebookLogin",
            CAP_PLUGIN_METHOD(getCurrentAccessToken, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getProfile, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(reauthorize, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(logEvent, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -11,4 +11,7 @@ CAP_PLUGIN(FacebookLogin, "FacebookLogin",
            CAP_PLUGIN_METHOD(getProfile, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(reauthorize, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(logEvent, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setAutoLogAppEventsEnabled, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setAdvertiserTrackingEnabled, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setAdvertiserIDCollectionEnabled, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -124,10 +124,37 @@ public class FacebookLogin: CAPPlugin {
     }
 
     @objc func logEvent(_ call: CAPPluginCall) {
-        if let eventName = call.getString("eventName") {
-            AppEvents.shared.logEvent(AppEvents.Name(eventName))
+        if let name = call.getString("name") {
+            AppEvents.shared.logEvent(AppEvents.Name(name))
         }
 
+        call.resolve()
+    }
+
+    @objc func setAutoLogAppEventsEnabled(_ call: CAPPluginCall) {
+        if let enabled = call.getBool("enabled") {
+            Settings.shared.isAutoLogAppEventsEnabled = enabled
+        } else {
+            Settings.shared.isAutoLogAppEventsEnabled = false
+        }
+        call.resolve()
+    }
+
+    @objc func setAdvertiserTrackingEnabled(_ call: CAPPluginCall) {
+        if let enabled = call.getBool("enabled") {
+            Settings.shared.isAdvertiserTrackingEnabled = enabled
+        } else {
+            Settings.shared.isAdvertiserTrackingEnabled = false
+        }
+        call.resolve()
+    }
+
+    @objc func setAdvertiserIDCollectionEnabled(_ call: CAPPluginCall) {
+        if let enabled = call.getBool("enabled") {
+            Settings.shared.isAdvertiserIDCollectionEnabled = enabled
+        } else {
+            Settings.shared.isAdvertiserIDCollectionEnabled = false
+        }
         call.resolve()
     }
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -122,4 +122,12 @@ public class FacebookLogin: CAPPlugin {
             call.resolve(result as! [String: Any])
         }
     }
+
+    @objc func logEvent(_ call: CAPPluginCall) {
+        if let eventName = call.getString("eventName") {
+            AppEvents.shared.logEvent(AppEvents.Name(eventName))
+        }
+
+        call.resolve()
+    }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -28,7 +28,10 @@ export interface FacebookLoginPlugin {
   getProfile<T extends object>(options: {
     fields: readonly string[];
   }): Promise<T>;
-  logEvent(options: { eventName: string }): Promise<void>;
+  logEvent(options: { name: string }): Promise<void>;
+  setAutoLogAppEventsEnabled(options: { enabled: boolean }): Promise<void>;
+  setAdvertiserTrackingEnabled(options: { enabled: boolean }): Promise<void>;
+  setAdvertiserIDCollectionEnabled(options: { enabled: boolean }): Promise<void>;
 }
 
 export interface FacebookGetLoginStatusResponse {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -28,6 +28,7 @@ export interface FacebookLoginPlugin {
   getProfile<T extends object>(options: {
     fields: readonly string[];
   }): Promise<T>;
+  logEvent(options: { eventName: string }): Promise<void>;
 }
 
 export interface FacebookGetLoginStatusResponse {

--- a/src/web.ts
+++ b/src/web.ts
@@ -40,6 +40,7 @@ declare interface Facebook {
     params: TParams,
     callback: (response: TResponse) => void,
   ): void;
+  logEvent(handle: (response: any) => void, options: { eventName: string }): void;
 }
 
 declare var FB: Facebook;
@@ -186,6 +187,14 @@ export class FacebookLoginWeb extends WebPlugin implements FacebookLoginPlugin {
           resolve(<T>response);
         },
       );
+    });
+  }
+
+  async logEvent(options: {
+    eventName: string;
+  }): Promise<void> {
+    return new Promise<void>(resolve => {
+      FB.logEvent(() => resolve(), {eventName: options.eventName});
     });
   }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -40,7 +40,10 @@ declare interface Facebook {
     params: TParams,
     callback: (response: TResponse) => void,
   ): void;
-  logEvent(handle: (response: any) => void, options: { eventName: string }): void;
+  logEvent(handle: (response: any) => void, options: { name: string }): void;
+  setAutoLogAppEventsEnabled(handle: (response: any) => void, options: { enabled: boolean }): void;
+  setAdvertiserTrackingEnabled(handle: (response: any) => void, options: { enabled: boolean }): void;
+  setAdvertiserIDCollectionEnabled(handle: (response: any) => void, options: { enabled: boolean }): void;
 }
 
 declare var FB: Facebook;
@@ -190,11 +193,19 @@ export class FacebookLoginWeb extends WebPlugin implements FacebookLoginPlugin {
     });
   }
 
-  async logEvent(options: {
-    eventName: string;
-  }): Promise<void> {
-    return new Promise<void>(resolve => {
-      FB.logEvent(() => resolve(), {eventName: options.eventName});
-    });
+  async logEvent(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async setAutoLogAppEventsEnabled(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async setAdvertiserTrackingEnabled(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async setAdvertiserIDCollectionEnabled(): Promise<void> {
+    return Promise.resolve();
   }
 }


### PR DESCRIPTION
Support sending Facebook App Events for iOS and Android

https://developers.facebook.com/docs/app-events/getting-started-app-events-ios#manually-log-events
https://developers.facebook.com/docs/app-events/getting-started-app-events-android#log-manually

```
Capacitor.Plugins.FacebookLogin.logEvent({eventName:'BattleTheMonster'})
```

I can confirm the correct code is executed on both android and iOS, but so far I have not been able to see the event on the Test Events tab.
https://business.facebook.com/events_manager2/list

I am not sure if additional configuration needs to be added or if there is an issue on how my datastore is configured.