### PR TITLE
Change "eventName" into "name" to fix custom events for Android

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
+++ b/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
@@ -304,7 +304,7 @@ public class FacebookLogin extends Plugin {
     @PluginMethod
     public void logEvent(final PluginCall call) {
         Log.d(getLogTag(), "Entering logEvent()");
-        String eventName = call.getString("eventName");
+        String eventName = call.getString("name");
         if (eventName != null) {
             logger.logEvent(eventName);
         }


### PR DESCRIPTION
Custom events for Android are not working because `call.getString` is looking for `eventName` when it should actually be looking for `name`