### PR TITLE
Return LoginManager.login error back to the plugin consumer

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -38,7 +38,7 @@ public class FacebookLogin: CAPPlugin {
             self.loginManager.logIn(permissions: permissions, from: self.bridge?.viewController) { result, error in
                 if let error = error {
                     print(error)
-                    call.reject("LoginManager.logIn failed")
+                    call.reject("LoginManager.logIn failed", nil, error)          
                 } else if let result = result, result.isCancelled {
                     print("User cancelled login")
                     call.resolve()

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -38,7 +38,7 @@ public class FacebookLogin: CAPPlugin {
             self.loginManager.logIn(permissions: permissions, from: self.bridge?.viewController) { result, error in
                 if let error = error {
                     print(error)
-                    call.reject("LoginManager.logIn failed", nil, error)          
+                    call.reject("LoginManager.logIn failed", nil, error.localizedDescription)          
                 } else if let result = result, result.isCancelled {
                     print("User cancelled login")
                     call.resolve()


### PR DESCRIPTION
In case something fails at the login sdk level, there is no information for the plugin consumer