### PR TITLE
chore: Bump version to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@capacitor-community/facebook-login",
-  "version": "7.0.0-0",
+  "version": "7.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@capacitor-community/facebook-login",
-      "version": "7.0.0-0",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/core": "^7.0.0"
@@ -29,7 +29,7 @@
         "typescript": "~4.1.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/facebook-login",
-  "version": "7.0.0-0",
+  "version": "7.0.0",
   "description": "A native plugin for Facebook Login",
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
latest published version is 7.0.0, but the repo still shows 7.0.0-0
and the package-lock.json was also out of date