### PR TITLE
fix(ios): Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ let package = Package(
     platforms: [.iOS(.v14)],
     products: [
         .library(
-            name: "FacebookLogin",
-            targets: ["FacebookLogin"])
+            name: "CapacitorCommunityFacebookLogin",
+            targets: ["FacebookLoginPlugin"])
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0"),
@@ -15,12 +15,12 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "FacebookLogin",
+            name: "FacebookLoginPlugin",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                .product(name: "FBSDKCoreKit", package: "facebook-ios-sdk"),
-                .product(name: "FBSDKLoginKit", package: "facebook-ios-sdk")
+                .product(name: "FacebookCore", package: "facebook-ios-sdk"),
+                .product(name: "FacebookLogin", package: "facebook-ios-sdk")
             ],
             path: "ios/Sources/FacebookLoginPlugin"),
         .testTarget(


### PR DESCRIPTION
library name has to match the package name for working on Capacitor projects
also the `FacebookLogin` target name conflicts with the same name used in the facebook sdk, so added `Plugin` to it to prevent the clash.

`FBSDKCoreKit` and `FBSDKLoginKit` don't seem to work anymore, updated them to `FacebookCore` and `FacebookLogin`