### PR TITLE
fix(android): Compile with Java 21

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
+    }
 }
 
 repositories {


### PR DESCRIPTION
running `verify:android` shows warnings about the plugin being compiled with Java 8 and being deprecated, so made it compile with Java 21