### PR TITLE
fix(demo): skip lib check

### DIFF
--- a/demo/angular/tsconfig.json
+++ b/demo/angular/tsconfig.json
@@ -11,6 +11,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
     "sourceMap": true,
     "declaration": false,
     "experimentalDecorators": true,


### PR DESCRIPTION
Ionic apps don't build with typescript 5.9, see https://github.com/ionic-team/ionic-framework/issues/30650

Recommended solutions are downgrading typescript or adding `"skipLibCheck": true,`.
I went with the second one since that's the one ionic starters used.