### PR TITLE
fix(ios): add Objective-C wrapper for FBSDK 18 Swift API compatibility

### DIFF
--- a/ios/Sources/FacebookLoginPlugin/FBSDKLoginHelper.h
+++ b/ios/Sources/FacebookLoginPlugin/FBSDKLoginHelper.h
@@ -1,0 +1,77 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Result block for login operations
+typedef void (^FBSDKLoginHelperResultBlock)(BOOL success, BOOL cancelled, NSString * _Nullable errorMessage);
+
+/// Result block for graph requests
+typedef void (^FBSDKLoginHelperGraphResultBlock)(NSDictionary * _Nullable result, NSString * _Nullable errorMessage);
+
+/// Objective-C helper to bridge FBSDK calls, avoiding Swift API gating issues with NonescapableTypes
+@interface FBSDKLoginHelper : NSObject
+
+/// Perform Facebook login with configuration
+/// @param viewController The view controller to present from
+/// @param permissions Array of permission strings
+/// @param trackingEnabled YES for .enabled tracking, NO for .limited
+/// @param nonce Optional nonce string (pass nil or empty to skip)
+/// @param completion Completion block with success/cancelled/error info
++ (void)loginFromViewController:(UIViewController *)viewController
+                    permissions:(NSArray<NSString *> *)permissions
+                trackingEnabled:(BOOL)trackingEnabled
+                          nonce:(nullable NSString *)nonce
+                     completion:(FBSDKLoginHelperResultBlock)completion;
+
+/// Perform reauthorization for data access
+/// @param viewController The view controller to present from
+/// @param completion Completion block
++ (void)reauthorizeDataAccessFromViewController:(UIViewController *)viewController
+                                     completion:(FBSDKLoginHelperResultBlock)completion;
+
+/// Log out the current user
++ (void)logOut;
+
+/// Check if there's a current access token
++ (BOOL)hasCurrentAccessToken;
+
+/// Check if the current access token's data access is expired
++ (BOOL)isDataAccessExpired;
+
+/// Get current access token string (from AccessToken or AuthenticationToken)
++ (nullable NSString *)currentTokenString;
+
+/// Get current user ID from access token
++ (nullable NSString *)currentUserID;
+
+/// Check if current access token is expired
++ (BOOL)isAccessTokenExpired;
+
+/// Perform a Graph API request
+/// @param graphPath The graph path (e.g., "me")
+/// @param parameters Request parameters
+/// @param completion Completion block with result dictionary or error
++ (void)graphRequestWithPath:(NSString *)graphPath
+                  parameters:(NSDictionary<NSString *, NSString *> *)parameters
+                  completion:(FBSDKLoginHelperGraphResultBlock)completion;
+
+/// Log an app event
+/// @param eventName The event name to log
++ (void)logEventWithName:(NSString *)eventName;
+
+/// Set auto log app events enabled
+/// @param enabled Whether to enable auto logging
++ (void)setAutoLogAppEventsEnabled:(BOOL)enabled;
+
+/// Set advertiser tracking enabled
+/// @param enabled Whether to enable advertiser tracking
++ (void)setAdvertiserTrackingEnabled:(BOOL)enabled;
+
+/// Set advertiser ID collection enabled
+/// @param enabled Whether to enable advertiser ID collection
++ (void)setAdvertiserIDCollectionEnabled:(BOOL)enabled;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Sources/FacebookLoginPlugin/FBSDKLoginHelper.m
+++ b/ios/Sources/FacebookLoginPlugin/FBSDKLoginHelper.m
@@ -1,0 +1,190 @@
+#import "FBSDKLoginHelper.h"
+@import FBSDKLoginKit;
+@import FBSDKCoreKit;
+
+@implementation FBSDKLoginHelper
+
++ (void)loginFromViewController:(UIViewController *)viewController
+                    permissions:(NSArray<NSString *> *)permissions
+                trackingEnabled:(BOOL)trackingEnabled
+                          nonce:(nullable NSString *)nonce
+                     completion:(FBSDKLoginHelperResultBlock)completion {
+    
+    FBSDKLoginManager *loginManager = [[FBSDKLoginManager alloc] init];
+    
+    // Create configuration using Obj-C API
+    FBSDKLoginConfiguration *configuration = nil;
+    FBSDKLoginTracking tracking = trackingEnabled ? FBSDKLoginTrackingEnabled : FBSDKLoginTrackingLimited;
+    
+    if (nonce != nil && nonce.length > 0) {
+        configuration = [[FBSDKLoginConfiguration alloc] initWithPermissions:permissions
+                                                                    tracking:tracking
+                                                                       nonce:nonce];
+    } else {
+        configuration = [[FBSDKLoginConfiguration alloc] initWithPermissions:permissions
+                                                                    tracking:tracking];
+    }
+    
+    if (configuration == nil) {
+        if (completion) {
+            completion(NO, NO, @"Invalid login configuration");
+        }
+        return;
+    }
+    
+    [loginManager logInFromViewController:viewController
+                            configuration:configuration
+                               completion:^(FBSDKLoginManagerLoginResult * _Nullable result, NSError * _Nullable error) {
+        if (error) {
+            if (completion) {
+                completion(NO, NO, error.localizedDescription);
+            }
+            return;
+        }
+        
+        if (result.isCancelled) {
+            if (completion) {
+                completion(NO, YES, nil);
+            }
+            return;
+        }
+        
+        if (completion) {
+            completion(YES, NO, nil);
+        }
+    }];
+}
+
++ (void)reauthorizeDataAccessFromViewController:(UIViewController *)viewController
+                                     completion:(FBSDKLoginHelperResultBlock)completion {
+    
+    // Check if we have a valid token that doesn't need reauth
+    FBSDKAccessToken *currentToken = FBSDKAccessToken.currentAccessToken;
+    if (currentToken != nil && !currentToken.isDataAccessExpired) {
+        if (completion) {
+            completion(YES, NO, nil);
+        }
+        return;
+    }
+    
+    FBSDKLoginManager *loginManager = [[FBSDKLoginManager alloc] init];
+    
+    [loginManager reauthorizeDataAccess:viewController
+                                handler:^(FBSDKLoginManagerLoginResult * _Nullable result, NSError * _Nullable error) {
+        if (error) {
+            if (completion) {
+                completion(NO, NO, error.localizedDescription);
+            }
+            return;
+        }
+        
+        if (result.isCancelled) {
+            if (completion) {
+                completion(NO, YES, nil);
+            }
+            return;
+        }
+        
+        if (completion) {
+            completion(YES, NO, nil);
+        }
+    }];
+}
+
++ (void)logOut {
+    FBSDKLoginManager *loginManager = [[FBSDKLoginManager alloc] init];
+    [loginManager logOut];
+}
+
++ (BOOL)hasCurrentAccessToken {
+    return FBSDKAccessToken.currentAccessToken != nil || FBSDKAuthenticationToken.currentAuthenticationToken != nil;
+}
+
++ (BOOL)isDataAccessExpired {
+    FBSDKAccessToken *token = FBSDKAccessToken.currentAccessToken;
+    if (token == nil) {
+        // In limited login mode, only AuthenticationToken exists (no AccessToken)
+        // Don't treat this as "expired" - return NO if we have an auth token
+        return FBSDKAuthenticationToken.currentAuthenticationToken == nil;
+    }
+    return token.isDataAccessExpired;
+}
+
++ (nullable NSString *)currentTokenString {
+    FBSDKAuthenticationToken *authToken = FBSDKAuthenticationToken.currentAuthenticationToken;
+    if (authToken != nil) {
+        return authToken.tokenString;
+    }
+    
+    FBSDKAccessToken *accessToken = FBSDKAccessToken.currentAccessToken;
+    if (accessToken != nil) {
+        return accessToken.tokenString;
+    }
+    
+    return nil;
+}
+
++ (nullable NSString *)currentUserID {
+    FBSDKAccessToken *accessToken = FBSDKAccessToken.currentAccessToken;
+    if (accessToken != nil) {
+        return accessToken.userID;
+    }
+    return nil;
+}
+
++ (BOOL)isAccessTokenExpired {
+    FBSDKAccessToken *accessToken = FBSDKAccessToken.currentAccessToken;
+    if (accessToken == nil) {
+        // In limited login mode, only AuthenticationToken exists (no AccessToken)
+        // Don't treat this as "expired" - return NO if we have an auth token
+        return FBSDKAuthenticationToken.currentAuthenticationToken == nil;
+    }
+    return accessToken.isExpired;
+}
+
++ (void)graphRequestWithPath:(NSString *)graphPath
+                  parameters:(NSDictionary<NSString *, NSString *> *)parameters
+                  completion:(FBSDKLoginHelperGraphResultBlock)completion {
+    
+    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:graphPath
+                                                                   parameters:parameters];
+    
+    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting> _Nullable connection,
+                                   id _Nullable result,
+                                   NSError * _Nullable error) {
+        if (error) {
+            if (completion) {
+                completion(nil, error.localizedDescription);
+            }
+            return;
+        }
+        
+        if ([result isKindOfClass:[NSDictionary class]]) {
+            if (completion) {
+                completion((NSDictionary *)result, nil);
+            }
+        } else {
+            if (completion) {
+                completion(nil, nil);
+            }
+        }
+    }];
+}
+
++ (void)logEventWithName:(NSString *)eventName {
+    [FBSDKAppEvents.shared logEvent:eventName];
+}
+
++ (void)setAutoLogAppEventsEnabled:(BOOL)enabled {
+    FBSDKSettings.sharedSettings.isAutoLogAppEventsEnabled = enabled;
+}
+
++ (void)setAdvertiserTrackingEnabled:(BOOL)enabled {
+    FBSDKSettings.sharedSettings.isAdvertiserTrackingEnabled = enabled;
+}
+
++ (void)setAdvertiserIDCollectionEnabled:(BOOL)enabled {
+    FBSDKSettings.sharedSettings.isAdvertiserIDCollectionEnabled = enabled;
+}
+
+@end

--- a/ios/Sources/FacebookLoginPlugin/FacebookLoginPlugin.swift
+++ b/ios/Sources/FacebookLoginPlugin/FacebookLoginPlugin.swift
@@ -1,11 +1,10 @@
 import Foundation
 import Capacitor
-import FBSDKLoginKit
 import CryptoKit
 
 /**
- * Please read the Capacitor iOS Plugin Development Guide
- * here: https://capacitorjs.com/docs/plugins/ios
+ * Facebook Login Plugin for Capacitor
+ * Uses Objective-C helper to avoid Swift API gating issues with FBSDK 18's NonescapableTypes requirement
  */
 @objc(FacebookLoginPlugin)
 public class FacebookLoginPlugin: CAPPlugin, CAPBridgedPlugin {
@@ -24,7 +23,6 @@ public class FacebookLoginPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "setAdvertiserIDCollectionEnabled", returnType: CAPPluginReturnPromise)
     ]
 
-    private let loginManager = LoginManager()
     private let dateFormatter = ISO8601DateFormatter()
 
     override public func load() {
@@ -47,38 +45,36 @@ public class FacebookLoginPlugin: CAPPlugin, CAPBridgedPlugin {
 
         let nonce = call.getString("nonce") ?? ""
         let tracking = call.getString("tracking") ?? "limited"
+        let trackingEnabled = tracking != "limited"
 
-        var configuration: LoginConfiguration?
-
-        if nonce.isEmpty {
-            configuration = LoginConfiguration(
-                permissions: permissions,
-                tracking: tracking == "limited" ? .limited : .enabled
-            )
-        } else {
-            configuration = LoginConfiguration(
-                permissions: permissions,
-                tracking: tracking == "limited" ? .limited : .enabled,
-                nonce: self.sha256(nonce)
-            )
-        }
-
-        guard let _ = configuration else {
-            // エラー処理
-            return
-        }
+        let hashedNonce = nonce.isEmpty ? nil : sha256(nonce)
 
         DispatchQueue.main.async {
-            self.loginManager.logIn(configuration: configuration) { result in
-                switch result {
-                case .cancelled:
+            guard let viewController = self.bridge?.viewController else {
+                call.reject("Missing view controller.")
+                return
+            }
+            
+            FBSDKLoginHelper.login(from: viewController,
+                                   permissions: permissions,
+                                   trackingEnabled: trackingEnabled,
+                                   nonce: hashedNonce) { success, cancelled, errorMessage in
+                if cancelled {
                     print("User cancelled login")
                     call.resolve()
-                case .failed:
-                    call.reject("LoginManager.logIn failed")
-                case .success:
+                    return
+                }
+                
+                if let error = errorMessage {
+                    call.reject("LoginManager.logIn failed: \(error)")
+                    return
+                }
+                
+                if success {
                     print("Logged in")
-                    return self.getCurrentAccessToken(call)
+                    self.getCurrentAccessToken(call)
+                } else {
+                    call.reject("Login failed")
                 }
             }
         }
@@ -91,54 +87,87 @@ public class FacebookLoginPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func logout(_ call: CAPPluginCall) {
-        loginManager.logOut()
+        FBSDKLoginHelper.logOut()
         call.resolve()
     }
 
     @objc func reauthorize(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            if let token = AccessToken.current, !token.isDataAccessExpired {
-                return self.getCurrentAccessToken(call)
-            } else {
-                self.loginManager.reauthorizeDataAccess(from: (self.bridge?.viewController)!) { (loginResult, error) in
-                    if (loginResult?.token) != nil {
-                        return self.getCurrentAccessToken(call)
-                    } else {
-                        print(error!)
-                        call.reject("LoginManager.reauthorize failed")
-                    }
+            // Check if we already have valid access
+            if FBSDKLoginHelper.hasCurrentAccessToken() && !FBSDKLoginHelper.isDataAccessExpired() {
+                self.getCurrentAccessToken(call)
+                return
+            }
+
+            guard let viewController = self.bridge?.viewController else {
+                call.reject("Missing view controller.")
+                return
+            }
+
+            FBSDKLoginHelper.reauthorizeDataAccess(from: viewController) { success, cancelled, errorMessage in
+                if cancelled {
+                    call.resolve()
+                    return
+                }
+                
+                if let error = errorMessage {
+                    call.reject("LoginManager.reauthorize failed: \(error)")
+                    return
+                }
+                
+                if success {
+                    self.getCurrentAccessToken(call)
+                } else {
+                    call.reject("Reauthorization failed")
                 }
             }
         }
     }
 
     @objc func getCurrentAccessToken(_ call: CAPPluginCall) {
-        guard let authenticationToken = AuthenticationToken.current else {
+        guard FBSDKLoginHelper.hasCurrentAccessToken() else {
             call.resolve()
             return
         }
 
-        guard let userProfile = Profile.current else {
-            call.resolve()
+        var accessTokenPayload: [String: Any] = [:]
+
+        if let tokenString = FBSDKLoginHelper.currentTokenString() {
+            accessTokenPayload["token"] = tokenString
+        }
+
+        if let userId = FBSDKLoginHelper.currentUserID() {
+            accessTokenPayload["userId"] = userId
+            
+            // Fetch profile info via Graph API
+            let parameters = ["fields": "id,name,email"]
+            FBSDKLoginHelper.graphRequest(withPath: "me", parameters: parameters) { result, errorMessage in
+                if let result = result {
+                    if let userId = result["id"] as? String {
+                        accessTokenPayload["userId"] = userId
+                    }
+                    if let name = result["name"] as? String {
+                        accessTokenPayload["name"] = name
+                    }
+                    if let email = result["email"] as? String {
+                        accessTokenPayload["email"] = email
+                    }
+                }
+                call.resolve(["accessToken": accessTokenPayload])
+            }
             return
         }
 
-        call.resolve([ "accessToken": [
-            "token": authenticationToken.tokenString,
-            "userId": userProfile.userID,
-            "name": userProfile.name,
-            "email": userProfile.email
-        ]
-        ])
+        call.resolve(["accessToken": accessTokenPayload])
     }
 
     @objc func getProfile(_ call: CAPPluginCall) {
-        guard let accessToken = AccessToken.current else {
+        guard FBSDKLoginHelper.hasCurrentAccessToken() else {
             call.reject("You're not logged in. Call FacebookLogin.login() first to obtain an access token.")
             return
         }
 
-        if accessToken.isExpired {
+        if FBSDKLoginHelper.isAccessTokenExpired() {
             call.reject("AccessToken is expired.")
             return
         }
@@ -147,47 +176,52 @@ public class FacebookLoginPlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject("Missing fields argument")
             return
         }
+        
         let parameters = ["fields": fields.joined(separator: ",")]
-        let graphRequest = GraphRequest.init(graphPath: "me", parameters: parameters)
 
-        graphRequest.start { (_ connection, _ result, _ error) in
-            if error != nil {
-                call.reject("An error has been occured.")
+        FBSDKLoginHelper.graphRequest(withPath: "me", parameters: parameters) { result, errorMessage in
+            if let error = errorMessage {
+                call.reject("An error has occurred: \(error)")
                 return
             }
 
-            call.resolve(result as! [String: Any])
+            if let result = result {
+                // Convert [AnyHashable: Any] to [String: Any]
+                var stringKeyedResult: [String: Any] = [:]
+                for (key, value) in result {
+                    if let stringKey = key as? String {
+                        stringKeyedResult[stringKey] = value
+                    }
+                }
+                call.resolve(stringKeyedResult)
+            } else {
+                call.reject("An error has occurred.")
+            }
         }
     }
 
     @objc func logEvent(_ call: CAPPluginCall) {
         if let eventName = call.getString("eventName") {
-            AppEvents.shared.logEvent(AppEvents.Name(eventName))
+            FBSDKLoginHelper.logEvent(withName: eventName)
         }
-
         call.resolve()
     }
 
     @objc func setAutoLogAppEventsEnabled(_ call: CAPPluginCall) {
-        if let enabled = call.getBool("enabled") {
-            Settings.shared.isAutoLogAppEventsEnabled = enabled
-        } else {
-            Settings.shared.isAutoLogAppEventsEnabled = false
-        }
+        let enabled = call.getBool("enabled") ?? false
+        FBSDKLoginHelper.setAutoLogAppEventsEnabled(enabled)
         call.resolve()
     }
 
     @objc func setAdvertiserTrackingEnabled(_ call: CAPPluginCall) {
-        Settings.shared.isAdvertiserTrackingEnabled = call.getBool("enabled", false)
+        let enabled = call.getBool("enabled") ?? false
+        FBSDKLoginHelper.setAdvertiserTrackingEnabled(enabled)
         call.resolve()
     }
 
     @objc func setAdvertiserIDCollectionEnabled(_ call: CAPPluginCall) {
-        if let enabled = call.getBool("enabled") {
-            Settings.shared.isAdvertiserIDCollectionEnabled = enabled
-        } else {
-            Settings.shared.isAdvertiserIDCollectionEnabled = false
-        }
+        let enabled = call.getBool("enabled") ?? false
+        FBSDKLoginHelper.setAdvertiserIDCollectionEnabled(enabled)
         call.resolve()
     }
 }


### PR DESCRIPTION
## Summary

FBSDK 18's Swift APIs are gated behind the experimental `NonescapableTypes` feature, which causes Swift compiler issues (circular reference errors) in some environments when trying to build with FBSDK 18.0.2+.

This PR adds an Objective-C helper (`FBSDKLoginHelper`) that wraps the FBSDK Objective-C APIs directly, bypassing the Swift API gating issue entirely.

## Problem

When using FBSDK 18 with the current Swift implementation, users may encounter:
- `'LoginConfiguration' cannot be constructed because it has no accessible initializers`
- Circular reference errors when `NonescapableTypes` experimental feature is enabled
- Unable to access `LoginTracking` enum values

This happens because FBSDK 18's Swift interface has certain APIs conditionally compiled:
```swift
#if compiler(>=5.3) && $NonescapableTypes
@objc(initWithPermissions:tracking:) convenience public init?(permissions: [Swift.String], tracking: FBSDKLoginKit.LoginTracking)
#endif
```

## Solution

The Objective-C APIs are **not gated** and work correctly. This PR:

1. **Adds `FBSDKLoginHelper.h/.m`** - An Objective-C wrapper that calls FBSDK's Obj-C APIs directly
2. **Updates `FacebookLoginPlugin.swift`** - Uses the Obj-C wrapper instead of calling Swift APIs
3. **Fixes limited-login edge case** - `isAccessTokenExpired` now returns `false` when only `AuthenticationToken` exists (no `AccessToken`), preventing incorrect "expired" errors in limited login mode

## Changes

- `ios/Sources/FacebookLoginPlugin/FBSDKLoginHelper.h` (new)
- `ios/Sources/FacebookLoginPlugin/FBSDKLoginHelper.m` (new)
- `ios/Sources/FacebookLoginPlugin/FacebookLoginPlugin.swift` (modified)

## Testing

- Tested with FBSDK 18.0.2
- Verified login, logout, getCurrentAccessToken, getProfile, logEvent, and settings methods work correctly
- Confirmed no deprecation warnings for ATT-related methods (FBSDK 18 reads ATT status automatically)

## Related

This issue affects users trying to use the plugin with FBSDK 18 and experiencing build failures.