### PR TITLE
Update default proguard file name for AGP 9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
Fixes https://github.com/capacitor-community/facebook-login/issues/196

Since the proguard-rules.pro file contains no rules anyway, it could alternatively just be removed including the buildTypes block in the build.gradle file.