### PR TITLE
chore: set "private": false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@capacitor-community/facebook-login",
+  "private": false,
   "version": "8.0.0",
   "description": "A native plugin for Facebook Login",
   "engines": {


### PR DESCRIPTION
Set `"private": false` in `package.json` to reflect that this repository is **public** on GitHub.