### PR TITLE
fix: handle web login consent and event parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,12 +346,12 @@ getProfile<T extends Record<string, unknown>>(options: { fields: readonly string
 ### logEvent(...)
 
 ```typescript
-logEvent(options: { eventName: string; }) => Promise<void>
+logEvent(options: { eventName: string; parameters?: Record<string, string | number>; }) => Promise<void>
 ```
 
-| Param         | Type                                |
-| ------------- | ----------------------------------- |
-| **`options`** | <code>{ eventName: string; }</code> |
+| Param         | Type                                                                                                           |
+| ------------- | -------------------------------------------------------------------------------------------------------------- |
+| **`options`** | <code>{ eventName: string; parameters?: <a href="#record">Record</a>&lt;string, string \| number&gt;; }</code> |
 
 --------------------
 

--- a/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
+++ b/android/src/main/java/com/getcapacitor/community/facebooklogin/FacebookLogin.java
@@ -31,6 +31,7 @@ import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.Locale;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -265,8 +266,10 @@ public class FacebookLogin extends Plugin {
         Log.d(getLogTag(), "Entering logEvent()");
         String eventName = call.getString("eventName");
         if (eventName != null) {
-            logger.logEvent(eventName);
+            logger.logEvent(eventName, parametersToBundle(call.getObject("parameters")));
         }
+
+        call.resolve();
     }
 
     @PluginMethod
@@ -315,6 +318,26 @@ public class FacebookLogin extends Plugin {
         }
 
         return json;
+    }
+
+    private Bundle parametersToBundle(JSObject parameters) {
+        Bundle bundle = new Bundle();
+        if (parameters == null) {
+            return bundle;
+        }
+
+        Iterator<String> keys = parameters.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            Object value = parameters.opt(key);
+            if (value instanceof String) {
+                bundle.putString(key, (String) value);
+            } else if (value instanceof Number) {
+                bundle.putDouble(key, ((Number) value).doubleValue());
+            }
+        }
+
+        return bundle;
     }
 
     private JSObject accessTokenToJson(AccessToken accessToken) {

--- a/ios/Sources/FacebookLoginPlugin/FacebookLoginPlugin.swift
+++ b/ios/Sources/FacebookLoginPlugin/FacebookLoginPlugin.swift
@@ -162,7 +162,12 @@ public class FacebookLoginPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func logEvent(_ call: CAPPluginCall) {
         if let eventName = call.getString("eventName") {
-            AppEvents.shared.logEvent(AppEvents.Name(eventName))
+            let parameters = call.getObject("parameters")?.reduce(into: [AppEvents.ParameterName: Any]()) { result, item in
+                if item.value is String || item.value is NSNumber {
+                    result[AppEvents.ParameterName(item.key)] = item.value
+                }
+            }
+            AppEvents.shared.logEvent(AppEvents.Name(eventName), parameters: parameters ?? [:])
         }
 
         call.resolve()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -38,7 +38,7 @@ export interface FacebookLoginPlugin {
   reauthorize(): Promise<FacebookLoginResponse>;
   getCurrentAccessToken(): Promise<FacebookCurrentAccessTokenResponse>;
   getProfile<T extends Record<string, unknown>>(options: { fields: readonly string[] }): Promise<T>;
-  logEvent(options: { eventName: string }): Promise<void>;
+  logEvent(options: { eventName: string; parameters?: Record<string, string | number> }): Promise<void>;
   setAutoLogAppEventsEnabled(options: { enabled: boolean }): Promise<void>;
   setAdvertiserTrackingEnabled(options: { enabled: boolean }): Promise<void>;
   setAdvertiserIDCollectionEnabled(options: { enabled: boolean }): Promise<void>;

--- a/src/web.ts
+++ b/src/web.ts
@@ -39,7 +39,9 @@ declare interface Facebook {
     params: TParams,
     callback: (response: TResponse) => void,
   ): void;
-  logEvent(handle: (response: any) => void, options: { eventName: string }): void;
+  AppEvents: {
+    logEvent(eventName: string, valueToSum?: number, parameters?: Record<string, string | number>): void;
+  };
   setAutoLogAppEventsEnabled(handle: (response: any) => void, options: { enabled: boolean }): void;
   setAdvertiserTrackingEnabled(handle: (response: any) => void, options: { enabled: boolean }): void;
   setAdvertiserIDCollectionEnabled(handle: (response: any) => void, options: { enabled: boolean }): void;
@@ -85,21 +87,31 @@ export class FacebookLoginWeb extends WebPlugin implements FacebookLoginPlugin {
 
   async login(options: { permissions: string[] }): Promise<FacebookLoginResponse> {
     return new Promise<FacebookLoginResponse>((resolve, reject) => {
+      const resolveWithAccessToken = (response: FacebookGetLoginStatusResponse): boolean => {
+        const token = response.authResponse?.accessToken;
+        if (response.status !== 'connected' || !token) {
+          return false;
+        }
+
+        resolve({
+          accessToken: {
+            token,
+          },
+        });
+        return true;
+      };
+
       FB.login(
         (response) => {
-          if (response.status === 'connected') {
-            resolve({
-              accessToken: {
-                token: response.authResponse.accessToken,
-              },
-            });
-          } else {
-            reject({
-              accessToken: {
-                token: null,
-              },
-            });
+          if (resolveWithAccessToken(response)) {
+            return;
           }
+
+          FB.getLoginStatus((statusResponse) => {
+            if (!resolveWithAccessToken(statusResponse)) {
+              reject('Facebook login did not return an access token.');
+            }
+          });
         },
         { scope: options.permissions.join(',') },
       );
@@ -156,8 +168,8 @@ export class FacebookLoginWeb extends WebPlugin implements FacebookLoginPlugin {
     });
   }
 
-  async logEvent(): Promise<void> {
-    return Promise.resolve();
+  async logEvent(options: { eventName: string; parameters?: Record<string, string | number> }): Promise<void> {
+    FB.AppEvents.logEvent(options.eventName, undefined, options.parameters);
   }
 
   async setAutoLogAppEventsEnabled(): Promise<void> {


### PR DESCRIPTION
## Summary

- re-check Facebook login status when the Web login callback does not contain an access token
- reject with a descriptive error when the re-check still has no token
- support string and numeric parameters in `logEvent` on Web, Android, and iOS

## Validation

- `npm run build`
- `npm run eslint`
- Android build, lint, and unit tests with JDK 21
- iOS demo app build for a generic iOS device with code signing disabled

Fixes #194
Fixes #160