### PR TITLE
docs: refresh README and API descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/maintenance/yes/2025?style=flat-square" />
+  <img src="https://img.shields.io/maintenance/yes/2026?style=flat-square" />
   <a href="https://www.npmjs.com/package/@capacitor-community/facebook-login"><img src="https://img.shields.io/npm/l/@capacitor-community/facebook-login?style=flat-square" /></a>
 <br>
   <a href="https://www.npmjs.com/package/@capacitor-community/facebook-login"><img src="https://img.shields.io/npm/dw/@capacitor-community/facebook-login?style=flat-square" /></a>
@@ -18,6 +18,8 @@
 | Maintainer          | GitHub                              | Social                                |
 | ------------------- | ----------------------------------- | ------------------------------------- |
 | Masahiko Sakakibara | [rdlabo](https://github.com/rdlabo) | [@rdlabo](https://twitter.com/rdlabo) |
+
+Maintenance Status: Actively Maintained
 
 ## Contributors ✨
 
@@ -31,20 +33,57 @@ Made with [contributors-img](https://contrib.rocks).
 
 [Demo code is here.](./demo/angular)
 
+## Overview
+
+Capacitor community plugin for Facebook Login and Facebook App Events on
+Android, iOS, and Web. It wraps the native Meta SDKs on Android and iOS and the
+Facebook JavaScript SDK on Web.
+
+## Features
+
+- Facebook login and logout, with native data access reauthorization
+- Current access token lookup
+- Facebook Graph API profile requests
+- Facebook App Events with string and number parameters
+- Native App Event and advertiser settings
+
+## Quick start
+
+After [Installation](#installation) and the platform configuration below,
+request the permissions your app needs:
+
+```ts
+import { FacebookLogin } from '@capacitor-community/facebook-login';
+
+const result = await FacebookLogin.login({ permissions: ['email'] });
+
+if (result.accessToken) {
+  console.log('Facebook login completed.');
+}
+```
+
 ## Installation
 
+This plugin targets Capacitor 8, iOS 15 or later, and Android API 24 or later.
+It already includes the native Facebook SDK dependencies.
+
 ```bash
-% npm i --save @capacitor-community/facebook-login
-% npx cap update
+npm install @capacitor-community/facebook-login
+npx cap sync
 ```
 
 ### Versions
 
-Users of Capacitor v6 should use version v6 of the Plugin.
+Install the plugin major version that matches your Capacitor major version.
 
-```bash
-% npm install @capacitor-community/facebook-login@6
-```
+| Capacitor | Plugin |
+| --------- | ------ |
+| 8         | 8.x    |
+| 7         | 7.x    |
+| 6         | 6.x    |
+
+For example, a Capacitor 7 application should install
+`@capacitor-community/facebook-login@7`.
 
 ## Configuration
 
@@ -76,17 +115,9 @@ This plugin will use the following project variables (defined in your app's `var
 
 ### iOS configuration
 
-In file `ios/App/Podfile` add the following:
-
-```diff
-  target 'App' do
-    capacitor_pods
-    # Add your Pods here
-+   pod 'FBSDKCoreKit'
-  end
-```
-
-In file `ios/App/App/AppDelegate.swift` add or replace the following:
+The plugin already includes `FBSDKCoreKit` and `FBSDKLoginKit`; do not add a
+second Facebook SDK dependency. In `ios/App/App/AppDelegate.swift`, add or
+replace the following:
 
 ```swift
 import UIKit
@@ -178,18 +209,38 @@ await FacebookLogin.initialize({ appId: '105890006170720' });
 ```
 
 More information can be found here: https://developers.facebook.com/docs/facebook-login/web
-And you must confirm return type at https://github.com/rdlabo/capacitor-facebook-login/blob/master/src/web.ts#L55-L57
-not same type for default web facebook login!
 
-## Example
+## Platform support
+
+| Method                                     | Android                     | iOS                         | Web                         |
+| ------------------------------------------ | --------------------------- | --------------------------- | --------------------------- |
+| `initialize`                               | No-op; configured natively  | No-op; configured natively  | Supported                   |
+| `login`                                    | Supported                   | Limited Login by default    | Supported                   |
+| `logout`                                   | Supported                   | Supported                   | Supported                   |
+| `reauthorize`                              | Supported                   | Supported                   | Not implemented             |
+| `getCurrentAccessToken`                    | Supported                   | Supported                   | Supported                   |
+| `getProfile`                               | Supported                   | Requires a Graph token      | Supported                   |
+| `logEvent`                                 | Supported                   | Supported                   | Supported                   |
+| `setAutoLogAppEventsEnabled`               | Promise remains pending     | Supported                   | No-op                       |
+| `setAdvertiserTrackingEnabled`             | Not implemented             | Supported                   | No-op                       |
+| `setAdvertiserIDCollectionEnabled`         | Promise remains pending     | Supported                   | No-op                       |
+
+`tracking` is an iOS-only login option and defaults to `limited`. In Limited
+Login, iOS returns an OIDC authentication token (JWT), not a Graph API access
+token. The plugin does not currently return the Graph access token obtained by
+`tracking: 'enabled'`. `nonce` is used by the Android and iOS login flows and is
+ignored on Web.
+
+On Android, `setAutoLogAppEventsEnabled` and
+`setAdvertiserIDCollectionEnabled` apply the requested value, but their
+returned promises currently remain pending.
+
+## Usage examples
 
 ### Login
 
 ```ts
-import {
-  FacebookLogin,
-  FacebookLoginResponse,
-} from '@capacitor-community/facebook-login';
+import { FacebookLogin } from '@capacitor-community/facebook-login';
 
 const FACEBOOK_PERMISSIONS = [
   'email',
@@ -197,13 +248,15 @@ const FACEBOOK_PERMISSIONS = [
   'user_photos',
   'user_gender',
 ];
-const result = await (<FacebookLoginResponse>(
-  FacebookLogin.login({ permissions: FACEBOOK_PERMISSIONS })
-));
+const result = await FacebookLogin.login({
+  permissions: FACEBOOK_PERMISSIONS,
+});
 
 if (result.accessToken) {
   // Login successful.
-  console.log(`Facebook access token is ${result.accessToken.token}`);
+  console.log(`Facebook token is ${result.accessToken.token}`);
+} else {
+  // No token was returned by the native platform.
 }
 ```
 
@@ -218,33 +271,73 @@ await FacebookLogin.logout();
 ### CurrentAccessToken
 
 ```ts
-import {
-  FacebookLogin,
-  FacebookLoginResponse,
-} from '@capacitor-community/facebook-login';
+import { FacebookLogin } from '@capacitor-community/facebook-login';
 
-const result = await (<FacebookLoginResponse>(
-  FacebookLogin.getCurrentAccessToken()
-));
+const result = await FacebookLogin.getCurrentAccessToken();
 
 if (result.accessToken) {
-  console.log(`Facebook access token is ${result.accessToken.token}`);
+  console.log(`Facebook token is ${result.accessToken.token}`);
 }
 ```
 
 ### getProfile
 
 ```ts
-import {
-  FacebookLogin,
-  FacebookLoginResponse,
-} from '@capacitor-community/facebook-login';
+import { FacebookLogin } from '@capacitor-community/facebook-login';
 
 const result = await FacebookLogin.getProfile<{
   email: string;
 }>({ fields: ['email'] });
 
 console.log(`Facebook user's email is ${result.email}`);
+```
+
+The requested fields must be permitted for your Meta app and granted by the
+user. The returned object contains only fields returned by the Graph API. On
+iOS, this requires a Graph access token and does not work with the default
+Limited Login token.
+
+### Reauthorize data access
+
+Data access reauthorization is available on Android and iOS only.
+
+```ts
+import { FacebookLogin } from '@capacitor-community/facebook-login';
+
+const result = await FacebookLogin.reauthorize();
+
+if (result.accessToken) {
+  console.log('Data access was renewed.');
+}
+```
+
+### Log an App Event
+
+```ts
+import { FacebookLogin } from '@capacitor-community/facebook-login';
+
+await FacebookLogin.logEvent({
+  eventName: 'completed_tutorial',
+  parameters: {
+    content_name: 'Getting Started',
+    step: 3,
+  },
+});
+```
+
+Event parameter values must be strings or numbers.
+
+### App Event and advertiser settings
+
+These settings can be awaited on iOS. Request App Tracking Transparency
+permission separately when needed.
+
+```ts
+import { FacebookLogin } from '@capacitor-community/facebook-login';
+
+await FacebookLogin.setAutoLogAppEventsEnabled({ enabled: true });
+await FacebookLogin.setAdvertiserIDCollectionEnabled({ enabled: true });
+await FacebookLogin.setAdvertiserTrackingEnabled({ enabled: true });
 ```
 
 ## API
@@ -275,6 +368,9 @@ console.log(`Facebook user's email is ${result.email}`);
 initialize(options: Partial<FacebookConfiguration>) => Promise<void>
 ```
 
+Initializes the Facebook JavaScript SDK on Web.
+This is a no-op on Android and iOS, where the SDK is configured natively.
+
 | Param         | Type                                                                                                          |
 | ------------- | ------------------------------------------------------------------------------------------------------------- |
 | **`options`** | <code><a href="#partial">Partial</a>&lt;<a href="#facebookconfiguration">FacebookConfiguration</a>&gt;</code> |
@@ -287,6 +383,9 @@ initialize(options: Partial<FacebookConfiguration>) => Promise<void>
 ```typescript
 login(options: { permissions: string[]; tracking?: 'limited' | 'enabled'; nonce?: string; }) => Promise<FacebookLoginResponse>
 ```
+
+Starts the Facebook login flow with the requested permissions.
+A cancelled native login resolves without a token.
 
 | Param         | Type                                                                                       |
 | ------------- | ------------------------------------------------------------------------------------------ |
@@ -303,6 +402,8 @@ login(options: { permissions: string[]; tracking?: 'limited' | 'enabled'; nonce?
 logout() => Promise<void>
 ```
 
+Logs out the current Facebook session.
+
 --------------------
 
 
@@ -311,6 +412,8 @@ logout() => Promise<void>
 ```typescript
 reauthorize() => Promise<FacebookLoginResponse>
 ```
+
+Requests renewed data access for the current Facebook session.
 
 **Returns:** <code>Promise&lt;<a href="#facebookloginresponse">FacebookLoginResponse</a>&gt;</code>
 
@@ -323,6 +426,10 @@ reauthorize() => Promise<FacebookLoginResponse>
 getCurrentAccessToken() => Promise<FacebookCurrentAccessTokenResponse>
 ```
 
+Returns the current token. iOS returns an OIDC authentication token for
+Limited Login. Native platforms resolve without a token when logged out;
+Web rejects when there is no connected Facebook session.
+
 **Returns:** <code>Promise&lt;<a href="#facebookcurrentaccesstokenresponse">FacebookCurrentAccessTokenResponse</a>&gt;</code>
 
 --------------------
@@ -333,6 +440,8 @@ getCurrentAccessToken() => Promise<FacebookCurrentAccessTokenResponse>
 ```typescript
 getProfile<T extends Record<string, unknown>>(options: { fields: readonly string[]; }) => Promise<T>
 ```
+
+Requests the selected fields from the Facebook Graph API `/me` endpoint.
 
 | Param         | Type                                        |
 | ------------- | ------------------------------------------- |
@@ -349,6 +458,8 @@ getProfile<T extends Record<string, unknown>>(options: { fields: readonly string
 logEvent(options: { eventName: string; parameters?: Record<string, string | number>; }) => Promise<void>
 ```
 
+Logs a Facebook App Event with optional string or number parameters.
+
 | Param         | Type                                                                                                           |
 | ------------- | -------------------------------------------------------------------------------------------------------------- |
 | **`options`** | <code>{ eventName: string; parameters?: <a href="#record">Record</a>&lt;string, string \| number&gt;; }</code> |
@@ -361,6 +472,8 @@ logEvent(options: { eventName: string; parameters?: Record<string, string | numb
 ```typescript
 setAutoLogAppEventsEnabled(options: { enabled: boolean; }) => Promise<void>
 ```
+
+Enables or disables automatic App Event logging on native platforms.
 
 | Param         | Type                               |
 | ------------- | ---------------------------------- |
@@ -375,6 +488,8 @@ setAutoLogAppEventsEnabled(options: { enabled: boolean; }) => Promise<void>
 setAdvertiserTrackingEnabled(options: { enabled: boolean; }) => Promise<void>
 ```
 
+Enables or disables advertiser tracking on iOS.
+
 | Param         | Type                               |
 | ------------- | ---------------------------------- |
 | **`options`** | <code>{ enabled: boolean; }</code> |
@@ -388,6 +503,8 @@ setAdvertiserTrackingEnabled(options: { enabled: boolean; }) => Promise<void>
 setAdvertiserIDCollectionEnabled(options: { enabled: boolean; }) => Promise<void>
 ```
 
+Enables or disables advertiser ID collection on native platforms.
+
 | Param         | Type                               |
 | ------------- | ---------------------------------- |
 | **`options`** | <code>{ enabled: boolean; }</code> |
@@ -400,43 +517,43 @@ setAdvertiserIDCollectionEnabled(options: { enabled: boolean; }) => Promise<void
 
 #### FacebookConfiguration
 
-| Prop                   | Type                 |
-| ---------------------- | -------------------- |
-| **`appId`**            | <code>string</code>  |
-| **`autoLogAppEvents`** | <code>boolean</code> |
-| **`xfbml`**            | <code>boolean</code> |
-| **`version`**          | <code>string</code>  |
-| **`locale`**           | <code>string</code>  |
+| Prop                   | Type                 | Description                                                          |
+| ---------------------- | -------------------- | -------------------------------------------------------------------- |
+| **`appId`**            | <code>string</code>  | Meta application ID.                                                 |
+| **`autoLogAppEvents`** | <code>boolean</code> | Whether the Web SDK automatically logs App Events.                   |
+| **`xfbml`**            | <code>boolean</code> | Whether the Web SDK parses XFBML social plugins.                     |
+| **`version`**          | <code>string</code>  | Facebook Graph API version used by the Web SDK. Defaults to `v17.0`. |
+| **`locale`**           | <code>string</code>  | Locale used to load the Web SDK. Defaults to `en_US`.                |
 
 
 #### FacebookLoginResponse
 
-| Prop                             | Type                                                        |
-| -------------------------------- | ----------------------------------------------------------- |
-| **`accessToken`**                | <code><a href="#accesstoken">AccessToken</a> \| null</code> |
-| **`recentlyGrantedPermissions`** | <code>string[]</code>                                       |
-| **`recentlyDeniedPermissions`**  | <code>string[]</code>                                       |
+| Prop                             | Type                                                        | Description                                          |
+| -------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------- |
+| **`accessToken`**                | <code><a href="#accesstoken">AccessToken</a> \| null</code> | Token response when one is returned by the platform. |
+| **`recentlyGrantedPermissions`** | <code>string[]</code>                                       | Permissions granted during this login.               |
+| **`recentlyDeniedPermissions`**  | <code>string[]</code>                                       | Permissions denied during this login.                |
 
 
 #### AccessToken
 
-| Prop                      | Type                  |
-| ------------------------- | --------------------- |
-| **`applicationId`**       | <code>string</code>   |
-| **`declinedPermissions`** | <code>string[]</code> |
-| **`expires`**             | <code>string</code>   |
-| **`isExpired`**           | <code>boolean</code>  |
-| **`lastRefresh`**         | <code>string</code>   |
-| **`permissions`**         | <code>string[]</code> |
-| **`token`**               | <code>string</code>   |
-| **`userId`**              | <code>string</code>   |
+| Prop                      | Type                  | Description                                                                                                                              |
+| ------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **`applicationId`**       | <code>string</code>   | Meta application ID that issued the token.                                                                                               |
+| **`declinedPermissions`** | <code>string[]</code> | Permissions declined by the user.                                                                                                        |
+| **`expires`**             | <code>string</code>   | ISO 8601 token expiration date.                                                                                                          |
+| **`isExpired`**           | <code>boolean</code>  | Whether the token is expired.                                                                                                            |
+| **`lastRefresh`**         | <code>string</code>   | ISO 8601 date when the token was last refreshed.                                                                                         |
+| **`permissions`**         | <code>string[]</code> | Permissions granted to the token.                                                                                                        |
+| **`token`**               | <code>string</code>   | Token string returned by the platform. With iOS Limited Login, this is an OIDC authentication token (JWT), not a Graph API access token. |
+| **`userId`**              | <code>string</code>   | Facebook user ID associated with the token.                                                                                              |
 
 
 #### FacebookCurrentAccessTokenResponse
 
-| Prop              | Type                                                        |
-| ----------------- | ----------------------------------------------------------- |
-| **`accessToken`** | <code><a href="#accesstoken">AccessToken</a> \| null</code> |
+| Prop              | Type                                                        | Description                                                  |
+| ----------------- | ----------------------------------------------------------- | ------------------------------------------------------------ |
+| **`accessToken`** | <code><a href="#accesstoken">AccessToken</a> \| null</code> | Current token response when one is returned by the platform. |
 
 
 ### Type Aliases

--- a/README.md
+++ b/README.md
@@ -65,14 +65,13 @@ if (result.accessToken) {
 ## Installation
 
 This plugin targets Capacitor 8, iOS 15 or later, and Android API 24 or later.
-It already includes the native Facebook SDK dependencies.
+It declares the native Facebook SDK dependencies for both CocoaPods and Swift
+Package Manager.
 
 ```bash
 npm install @capacitor-community/facebook-login
 npx cap sync
 ```
-
-### Versions
 
 Install the plugin major version that matches your Capacitor major version.
 
@@ -82,263 +81,21 @@ Install the plugin major version that matches your Capacitor major version.
 | 7         | 7.x    |
 | 6         | 6.x    |
 
-For example, a Capacitor 7 application should install
-`@capacitor-community/facebook-login@7`.
+Complete the required native and Web setup in
+[Configuration](./docs/configuration.md) before calling the plugin.
 
-## Configuration
+## Documentation
 
-### Android configuration
+Start with [Configuration](./docs/configuration.md), then use the guide for the
+feature you are implementing. Method signatures and generated type information
+remain in the [API](#api) section below.
 
-In file `android/app/src/main/AndroidManifest.xml`, add the following XML elements under `<manifest><application>` :
-
-```xml
-<meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
-<meta-data android:name="com.facebook.sdk.ClientToken" android:value="@string/facebook_client_token"/>
-```
-
-In file `android/app/src/main/res/values/strings.xml` add the following lines :
-
-```xml
-<string name="facebook_app_id">[APP_ID]</string>
-<string name="facebook_client_token">[CLIENT_TOKEN]</string>
-```
-
-Don't forget to replace `[APP_ID]` and `[CLIENT_TOKEN]` by your Facebook application Id.
-
-More information can be found here: https://developers.facebook.com/docs/android/getting-started
-
-### Variables
-
-This plugin will use the following project variables (defined in your app's `variables.gradle` file):
-
-- `facebookSDKVersion`: version of `com.facebook.android:facebook-login` (default: `18.1.3`)
-
-### iOS configuration
-
-The plugin declares `FBSDKCoreKit` and `FBSDKLoginKit` as dependencies for
-CocoaPods and Swift Package Manager. Do not add the Facebook iOS SDK
-separately. In `ios/App/App/AppDelegate.swift`, add or replace the following:
-
-```swift
-import UIKit
-import Capacitor
-import FBSDKCoreKit
-
-@UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
-
-    var window: UIWindow?
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        FBSDKCoreKit.ApplicationDelegate.shared.application(
-            application,
-            didFinishLaunchingWithOptions: launchOptions
-        )
-
-        return true
-    }
-
-    ...
-
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        // Called when the app was launched with a url. Feel free to add additional processing here,
-        // but if you want the App API to support tracking app url opens, make sure to keep this call
-        if (FBSDKCoreKit.ApplicationDelegate.shared.application(
-            app,
-            open: url,
-            sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
-            annotation: options[UIApplication.OpenURLOptionsKey.annotation]
-        )) {
-            return true;
-        } else {
-            return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
-        }
-    }
-}
-```
-
-Add the following in the `ios/App/App/info.plist` file inside of the outermost `<dict>`:
-
-```xml
-
-<key>CFBundleURLTypes</key>
-<array>
-    <dict>
-        <key>CFBundleURLSchemes</key>
-        <array>
-            <string>fb[APP_ID]</string>
-        </array>
-    </dict>
-</array>
-<key>FacebookAppID</key>
-<string>[APP_ID]</string>
-<key>FacebookClientToken</key>
-<string>[CLIENT_TOKEN]</string>
-<key>FacebookDisplayName</key>
-<string>[APP_NAME]</string>
-<key>LSApplicationQueriesSchemes</key>
-<array>
-    <string>fbapi</string>
-    <string>fbapi20130214</string>
-    <string>fbapi20130410</string>
-    <string>fbapi20130702</string>
-    <string>fbapi20131010</string>
-    <string>fbapi20131219</string>
-    <string>fbapi20140410</string>
-    <string>fbapi20140116</string>
-    <string>fbapi20150313</string>
-    <string>fbapi20150629</string>
-    <string>fbapi20160328</string>
-    <string>fbauth</string>
-    <string>fb-messenger-share-api</string>
-    <string>fbauth2</string>
-    <string>fbshareextension</string>
-</array>
-```
-
-More information can be found here: https://developers.facebook.com/docs/facebook-login/ios
-
-### Web configuration
-
-```typescript
-import { FacebookLogin } from '@capacitor-community/facebook-login';
-
-// use hook after platform dom ready
-await FacebookLogin.initialize({ appId: '105890006170720' });
-```
-
-More information can be found here: https://developers.facebook.com/docs/facebook-login/web
-
-## Platform support
-
-| Method                                     | Android                     | iOS                         | Web                         |
-| ------------------------------------------ | --------------------------- | --------------------------- | --------------------------- |
-| `initialize`                               | No-op; configured natively  | No-op; configured natively  | Supported                   |
-| `login`                                    | Supported                   | Limited Login by default    | Supported                   |
-| `logout`                                   | Supported                   | Supported                   | Supported                   |
-| `reauthorize`                              | Supported                   | Supported                   | Not implemented             |
-| `getCurrentAccessToken`                    | Supported                   | Supported                   | Supported                   |
-| `getProfile`                               | Supported                   | Requires a Graph token      | Supported                   |
-| `logEvent`                                 | Supported                   | Supported                   | Supported                   |
-| `setAutoLogAppEventsEnabled`               | Promise remains pending     | Supported                   | No-op                       |
-| `setAdvertiserTrackingEnabled`             | Not implemented             | Supported                   | No-op                       |
-| `setAdvertiserIDCollectionEnabled`         | Promise remains pending     | Supported                   | No-op                       |
-
-`tracking` is an iOS-only login option and defaults to `limited`. In Limited
-Login, iOS returns an OIDC authentication token (JWT), not a Graph API access
-token. The plugin does not currently return the Graph access token obtained by
-`tracking: 'enabled'`. `nonce` is used by the Android and iOS login flows and is
-ignored on Web.
-
-On Android, `setAutoLogAppEventsEnabled` and
-`setAdvertiserIDCollectionEnabled` apply the requested value, but their
-returned promises currently remain pending.
-
-## Usage examples
-
-### Login
-
-```ts
-import { FacebookLogin } from '@capacitor-community/facebook-login';
-
-const FACEBOOK_PERMISSIONS = [
-  'email',
-  'user_birthday',
-  'user_photos',
-  'user_gender',
-];
-const result = await FacebookLogin.login({
-  permissions: FACEBOOK_PERMISSIONS,
-});
-
-if (result.accessToken) {
-  // Login successful.
-  console.log(`Facebook token is ${result.accessToken.token}`);
-} else {
-  // No token was returned by the native platform.
-}
-```
-
-### Logout
-
-```ts
-import { FacebookLogin } from '@capacitor-community/facebook-login';
-
-await FacebookLogin.logout();
-```
-
-### CurrentAccessToken
-
-```ts
-import { FacebookLogin } from '@capacitor-community/facebook-login';
-
-const result = await FacebookLogin.getCurrentAccessToken();
-
-if (result.accessToken) {
-  console.log(`Facebook token is ${result.accessToken.token}`);
-}
-```
-
-### getProfile
-
-```ts
-import { FacebookLogin } from '@capacitor-community/facebook-login';
-
-const result = await FacebookLogin.getProfile<{
-  email: string;
-}>({ fields: ['email'] });
-
-console.log(`Facebook user's email is ${result.email}`);
-```
-
-The requested fields must be permitted for your Meta app and granted by the
-user. The returned object contains only fields returned by the Graph API. On
-iOS, this requires a Graph access token and does not work with the default
-Limited Login token.
-
-### Reauthorize data access
-
-Data access reauthorization is available on Android and iOS only.
-
-```ts
-import { FacebookLogin } from '@capacitor-community/facebook-login';
-
-const result = await FacebookLogin.reauthorize();
-
-if (result.accessToken) {
-  console.log('Data access was renewed.');
-}
-```
-
-### Log an App Event
-
-```ts
-import { FacebookLogin } from '@capacitor-community/facebook-login';
-
-await FacebookLogin.logEvent({
-  eventName: 'completed_tutorial',
-  parameters: {
-    content_name: 'Getting Started',
-    step: 3,
-  },
-});
-```
-
-Event parameter values must be strings or numbers.
-
-### App Event and advertiser settings
-
-These settings can be awaited on iOS. Request App Tracking Transparency
-permission separately when needed.
-
-```ts
-import { FacebookLogin } from '@capacitor-community/facebook-login';
-
-await FacebookLogin.setAutoLogAppEventsEnabled({ enabled: true });
-await FacebookLogin.setAdvertiserIDCollectionEnabled({ enabled: true });
-await FacebookLogin.setAdvertiserTrackingEnabled({ enabled: true });
-```
+- [Configuration](./docs/configuration.md) — Meta app settings and Android, iOS,
+  and Web SDK setup.
+- [Authentication](./docs/authentication.md) — login, logout, current tokens,
+  profile fields, reauthorization, and platform differences.
+- [App Events](./docs/app-events.md) — custom events, parameters, automatic event
+  logging, and advertiser settings.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ This plugin will use the following project variables (defined in your app's `var
 
 ### iOS configuration
 
-The plugin already includes `FBSDKCoreKit` and `FBSDKLoginKit`; do not add a
-second Facebook SDK dependency. In `ios/App/App/AppDelegate.swift`, add or
-replace the following:
+The plugin declares `FBSDKCoreKit` and `FBSDKLoginKit` as dependencies for
+CocoaPods and Swift Package Manager. Do not add the Facebook iOS SDK
+separately. In `ios/App/App/AppDelegate.swift`, add or replace the following:
 
 ```swift
 import UIKit

--- a/docs/app-events.md
+++ b/docs/app-events.md
@@ -1,0 +1,42 @@
+# App Events
+
+Complete [Configuration](./configuration.md) before logging Facebook App Events.
+
+## Platform behavior
+
+| Method                             | Android                 | iOS       | Web       |
+| ---------------------------------- | ----------------------- | --------- | --------- |
+| `logEvent`                         | Supported               | Supported | Supported |
+| `setAutoLogAppEventsEnabled`       | Promise remains pending | Supported | No-op     |
+| `setAdvertiserTrackingEnabled`     | Not implemented         | Supported | No-op     |
+| `setAdvertiserIDCollectionEnabled` | Promise remains pending | Supported | No-op     |
+
+## Log an event
+
+```ts
+import { FacebookLogin } from '@capacitor-community/facebook-login';
+
+await FacebookLogin.logEvent({
+  eventName: 'completed_tutorial',
+  parameters: {
+    content_name: 'Getting Started',
+    step: 3,
+  },
+});
+```
+
+Parameter values must be strings or numbers. Other value types are not part of the public API and are ignored by the native implementations.
+
+## Automatic events and advertiser settings
+
+These settings can be awaited on iOS:
+
+```ts
+await FacebookLogin.setAutoLogAppEventsEnabled({ enabled: true });
+await FacebookLogin.setAdvertiserIDCollectionEnabled({ enabled: true });
+await FacebookLogin.setAdvertiserTrackingEnabled({ enabled: true });
+```
+
+Request App Tracking Transparency permission separately before enabling advertiser tracking when your iOS app requires it.
+
+On Android, `setAutoLogAppEventsEnabled` and `setAdvertiserIDCollectionEnabled` apply the requested value, but their returned promises currently remain pending. `setAdvertiserTrackingEnabled` is not implemented on Android. All three methods are no-ops on Web.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,92 @@
+# Authentication
+
+Complete [Configuration](./configuration.md) before using the authentication methods.
+
+## Platform behavior
+
+| Method                  | Android   | iOS                      | Web             |
+| ----------------------- | --------- | ------------------------ | --------------- |
+| `login`                 | Supported | Limited Login by default | Supported       |
+| `logout`                | Supported | Supported                | Supported       |
+| `reauthorize`           | Supported | Supported                | Not implemented |
+| `getCurrentAccessToken` | Supported | Limited Login token      | Supported       |
+| `getProfile`            | Supported | Requires a Graph token   | Supported       |
+
+The `tracking` login option is iOS-only and defaults to `limited`. In Limited Login, iOS returns an OIDC authentication token (JWT), not a Graph API access token. The plugin does not currently return the Graph access token obtained with `tracking: 'enabled'`.
+
+The `nonce` option is used by Android and iOS and ignored on Web. Pass the raw nonce; the native implementations hash it before giving it to the Facebook SDK.
+
+## Login
+
+Request only the permissions your app uses:
+
+```ts
+import { FacebookLogin } from '@capacitor-community/facebook-login';
+
+const result = await FacebookLogin.login({
+  permissions: ['email', 'user_birthday'],
+});
+
+if (result.accessToken) {
+  console.log(`Facebook token: ${result.accessToken.token}`);
+} else {
+  // No token was returned by the native platform.
+}
+```
+
+On Web, login rejects if Facebook does not return a usable token. On Android and iOS, a cancelled login resolves without a token.
+
+### iOS tracking mode and nonce
+
+```ts
+const result = await FacebookLogin.login({
+  permissions: ['email'],
+  tracking: 'limited',
+  nonce: crypto.randomUUID(),
+});
+```
+
+Limited Login tokens should be validated as OIDC tokens by your backend. Do not treat them as Graph API access tokens.
+
+## Current token
+
+```ts
+const result = await FacebookLogin.getCurrentAccessToken();
+
+if (result.accessToken) {
+  console.log(`Current Facebook token: ${result.accessToken.token}`);
+}
+```
+
+Native platforms resolve without a token when logged out. Web rejects when there is no connected Facebook session.
+
+## Profile fields
+
+```ts
+const profile = await FacebookLogin.getProfile<{
+  id: string;
+  email?: string;
+}>({ fields: ['id', 'email'] });
+```
+
+The fields must be permitted for your Meta app and granted by the user. The returned object contains only fields returned by the Graph API. On iOS, this requires a Graph access token and does not work with the default Limited Login token.
+
+## Reauthorize data access
+
+Reauthorization is available on Android and iOS only.
+
+```ts
+const result = await FacebookLogin.reauthorize();
+
+if (result.accessToken) {
+  console.log('Data access was renewed.');
+}
+```
+
+## Logout
+
+```ts
+await FacebookLogin.logout();
+```
+
+Logging out clears the Facebook session managed by the platform SDK.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,135 @@
+# Configuration
+
+Create or select an app in the [Meta App Dashboard](https://developers.facebook.com/apps/), enable Facebook Login, and configure each platform that your Capacitor app supports.
+
+The plugin targets Capacitor 8, iOS 15 or later, and Android API 24 or later. It declares the native Facebook SDK dependencies, so do not add a second Facebook SDK dependency.
+
+## Android
+
+In `android/app/src/main/AndroidManifest.xml`, add the following inside `<application>`:
+
+```xml
+<meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id" />
+<meta-data android:name="com.facebook.sdk.ClientToken" android:value="@string/facebook_client_token" />
+```
+
+In `android/app/src/main/res/values/strings.xml`:
+
+```xml
+<string name="facebook_app_id">[APP_ID]</string>
+<string name="facebook_client_token">[CLIENT_TOKEN]</string>
+```
+
+Replace `[APP_ID]` and `[CLIENT_TOKEN]` with values from your Meta app. Add your Android package name, activity class, and release/debug key hashes in the Meta App Dashboard. See Meta's [Android getting started guide](https://developers.facebook.com/docs/android/getting-started).
+
+### Android variables
+
+Override the following in your app's `variables.gradle` only when you need a specific SDK version:
+
+| Variable             | Artifact                              | Default  |
+| -------------------- | ------------------------------------- | -------- |
+| `facebookSDKVersion` | `com.facebook.android:facebook-login` | `18.1.3` |
+
+## iOS
+
+The plugin declares `FBSDKCoreKit` and `FBSDKLoginKit` as dependencies for CocoaPods and Swift Package Manager. Do not add the Facebook iOS SDK separately.
+
+In `ios/App/App/AppDelegate.swift`, initialize the SDK and forward the login callback URL:
+
+```swift
+import UIKit
+import Capacitor
+import FBSDKCoreKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        ApplicationDelegate.shared.application(
+            application,
+            didFinishLaunchingWithOptions: launchOptions
+        )
+        return true
+    }
+
+    func application(
+        _ app: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    ) -> Bool {
+        if ApplicationDelegate.shared.application(
+            app,
+            open: url,
+            sourceApplication: options[.sourceApplication] as? String,
+            annotation: options[.annotation]
+        ) {
+            return true
+        }
+        return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
+    }
+}
+```
+
+Add the following inside the outermost `<dict>` in `ios/App/App/Info.plist`:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>fb[APP_ID]</string>
+    </array>
+  </dict>
+</array>
+<key>FacebookAppID</key>
+<string>[APP_ID]</string>
+<key>FacebookClientToken</key>
+<string>[CLIENT_TOKEN]</string>
+<key>FacebookDisplayName</key>
+<string>[APP_NAME]</string>
+<key>LSApplicationQueriesSchemes</key>
+<array>
+  <string>fbapi</string>
+  <string>fbapi20130214</string>
+  <string>fbapi20130410</string>
+  <string>fbapi20130702</string>
+  <string>fbapi20131010</string>
+  <string>fbapi20131219</string>
+  <string>fbapi20140410</string>
+  <string>fbapi20140116</string>
+  <string>fbapi20150313</string>
+  <string>fbapi20150629</string>
+  <string>fbapi20160328</string>
+  <string>fbauth</string>
+  <string>fb-messenger-share-api</string>
+  <string>fbauth2</string>
+  <string>fbshareextension</string>
+</array>
+```
+
+Replace all placeholders with values from your Meta app. Add the bundle ID to the iOS platform in the Meta App Dashboard. See Meta's [iOS login guide](https://developers.facebook.com/docs/facebook-login/ios).
+
+## Web
+
+Initialize the Facebook JavaScript SDK after the DOM is available and before calling other plugin methods:
+
+```ts
+import { FacebookLogin } from '@capacitor-community/facebook-login';
+
+await FacebookLogin.initialize({
+  appId: '[APP_ID]',
+  locale: 'en_US',
+});
+```
+
+`initialize` is a no-op on Android and iOS because those SDKs are configured natively. Web defaults to Graph API `v17.0` and locale `en_US` when those options are omitted. See Meta's [Web login guide](https://developers.facebook.com/docs/facebook-login/web).
+
+## Next steps
+
+- [Authentication](./authentication.md)
+- [App Events](./app-events.md)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "android/src/main/",
     "android/build.gradle",
     "dist/",
+    "docs/",
     "ios/Sources",
     "ios/Tests",
     "Package.swift",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,27 +1,51 @@
 export interface AccessToken {
+  /** Meta application ID that issued the token. */
   applicationId?: string;
+  /** Permissions declined by the user. */
   declinedPermissions?: string[];
+  /** ISO 8601 token expiration date. */
   expires?: string;
+  /** Whether the token is expired. */
   isExpired?: boolean;
+  /** ISO 8601 date when the token was last refreshed. */
   lastRefresh?: string;
+  /** Permissions granted to the token. */
   permissions?: string[];
+  /**
+   * Token string returned by the platform. With iOS Limited Login, this is an
+   * OIDC authentication token (JWT), not a Graph API access token.
+   */
   token: string;
+  /** Facebook user ID associated with the token. */
   userId?: string;
 }
 
 export interface FacebookLoginResponse {
+  /** Token response when one is returned by the platform. */
   accessToken: AccessToken | null;
+  /** Permissions granted during this login. */
   recentlyGrantedPermissions?: string[];
+  /** Permissions denied during this login. */
   recentlyDeniedPermissions?: string[];
 }
 
 export interface FacebookCurrentAccessTokenResponse {
+  /** Current token response when one is returned by the platform. */
   accessToken: AccessToken | null;
 }
 
 export interface FacebookLoginPlugin {
+  /**
+   * Initializes the Facebook JavaScript SDK on Web.
+   * This is a no-op on Android and iOS, where the SDK is configured natively.
+   */
   initialize(options: Partial<FacebookConfiguration>): Promise<void>;
+  /**
+   * Starts the Facebook login flow with the requested permissions.
+   * A cancelled native login resolves without a token.
+   */
   login(options: {
+    /** Facebook permissions to request. */
     permissions: string[];
     /**
      * Limited Login: iOS Only.
@@ -34,13 +58,25 @@ export interface FacebookLoginPlugin {
      */
     nonce?: string;
   }): Promise<FacebookLoginResponse>;
+  /** Logs out the current Facebook session. */
   logout(): Promise<void>;
+  /** Requests renewed data access for the current Facebook session. */
   reauthorize(): Promise<FacebookLoginResponse>;
+  /**
+   * Returns the current token. iOS returns an OIDC authentication token for
+   * Limited Login. Native platforms resolve without a token when logged out;
+   * Web rejects when there is no connected Facebook session.
+   */
   getCurrentAccessToken(): Promise<FacebookCurrentAccessTokenResponse>;
+  /** Requests the selected fields from the Facebook Graph API `/me` endpoint. */
   getProfile<T extends Record<string, unknown>>(options: { fields: readonly string[] }): Promise<T>;
+  /** Logs a Facebook App Event with optional string or number parameters. */
   logEvent(options: { eventName: string; parameters?: Record<string, string | number> }): Promise<void>;
+  /** Enables or disables automatic App Event logging on native platforms. */
   setAutoLogAppEventsEnabled(options: { enabled: boolean }): Promise<void>;
+  /** Enables or disables advertiser tracking on iOS. */
   setAdvertiserTrackingEnabled(options: { enabled: boolean }): Promise<void>;
+  /** Enables or disables advertiser ID collection on native platforms. */
   setAdvertiserIDCollectionEnabled(options: { enabled: boolean }): Promise<void>;
 }
 
@@ -66,9 +102,14 @@ export interface FacebookGetProfileResponse {
 }
 
 export interface FacebookConfiguration {
+  /** Meta application ID. */
   appId: string;
+  /** Whether the Web SDK automatically logs App Events. */
   autoLogAppEvents: boolean;
+  /** Whether the Web SDK parses XFBML social plugins. */
   xfbml: boolean;
+  /** Facebook Graph API version used by the Web SDK. Defaults to `v17.0`. */
   version: string;
+  /** Locale used to load the Web SDK. Defaults to `en_US`. */
   locale: string;
 }


### PR DESCRIPTION
## Summary

- align the README structure and maintenance status with the current Capacitor 8 release
- document platform-specific behavior and limitations for Android, iOS, and Web
- add quick-start and usage examples for login, profile, reauthorization, App Events, and advertiser settings
- add JSDoc descriptions and regenerate the API reference with docgen

## Validation

- `npm run build`
- `git diff --check`

The documentation reflects the current implementation, including iOS Limited Login tokens, unavailable Web reauthorization, and the pending Android setter promises.