### PR TITLE
chore: update Facebook SDK and Graph API versions

### DIFF
--- a/CapacitorCommunityFacebookLogin.podspec
+++ b/CapacitorCommunityFacebookLogin.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.1'
   s.static_framework = true
   s.dependency 'Capacitor'
-  s.dependency 'FBSDKCoreKit', '~> 18.0'
-  s.dependency 'FBSDKLoginKit', '~> 18.0'
+  s.dependency 'FBSDKCoreKit', '~> 18.1'
+  s.dependency 'FBSDKLoginKit', '~> 18.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/facebook/facebook-ios-sdk.git", .upToNextMajor(from: "17.4.0"))
+        .package(url: "https://github.com/facebook/facebook-ios-sdk.git", .upToNextMajor(from: "18.1.0"))
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Enables or disables advertiser ID collection on native platforms.
 | **`appId`**            | <code>string</code>  | Meta application ID.                                                 |
 | **`autoLogAppEvents`** | <code>boolean</code> | Whether the Web SDK automatically logs App Events.                   |
 | **`xfbml`**            | <code>boolean</code> | Whether the Web SDK parses XFBML social plugins.                     |
-| **`version`**          | <code>string</code>  | Facebook Graph API version used by the Web SDK. Defaults to `v17.0`. |
+| **`version`**          | <code>string</code>  | Facebook Graph API version used by the Web SDK. Defaults to `v26.0`. |
 | **`locale`**           | <code>string</code>  | Locale used to load the Web SDK. Defaults to `en_US`.                |
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
-    facebookSDKVersion = project.hasProperty('facebookSDKVersion') ? rootProject.ext.facebookSDKVersion : '18.1.3'
+    facebookSDKVersion = project.hasProperty('facebookSDKVersion') ? rootProject.ext.facebookSDKVersion : '18.3.0'
 }
 
 buildscript {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,11 +28,14 @@ Override the following in your app's `variables.gradle` only when you need a spe
 
 | Variable             | Artifact                              | Default  |
 | -------------------- | ------------------------------------- | -------- |
-| `facebookSDKVersion` | `com.facebook.android:facebook-login` | `18.1.3` |
+| `facebookSDKVersion` | `com.facebook.android:facebook-login` | `18.3.0` |
 
 ## iOS
 
 The plugin declares `FBSDKCoreKit` and `FBSDKLoginKit` as dependencies for CocoaPods and Swift Package Manager. Do not add the Facebook iOS SDK separately.
+
+The CocoaPods dependencies use `~> 18.1`, and Swift Package Manager resolves
+from `18.1.0` up to the next major version.
 
 In `ios/App/App/AppDelegate.swift`, initialize the SDK and forward the login callback URL:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,7 +130,7 @@ await FacebookLogin.initialize({
 });
 ```
 
-`initialize` is a no-op on Android and iOS because those SDKs are configured natively. Web defaults to Graph API `v17.0` and locale `en_US` when those options are omitted. See Meta's [Web login guide](https://developers.facebook.com/docs/facebook-login/web).
+`initialize` is a no-op on Android and iOS because those SDKs are configured natively. Web defaults to Graph API `v26.0` and locale `en_US` when those options are omitted. See Meta's [Web login guide](https://developers.facebook.com/docs/facebook-login/web).
 
 ## Next steps
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -108,7 +108,7 @@ export interface FacebookConfiguration {
   autoLogAppEvents: boolean;
   /** Whether the Web SDK parses XFBML social plugins. */
   xfbml: boolean;
-  /** Facebook Graph API version used by the Web SDK. Defaults to `v17.0`. */
+  /** Facebook Graph API version used by the Web SDK. Defaults to `v26.0`. */
   version: string;
   /** Locale used to load the Web SDK. Defaults to `en_US`. */
   locale: string;

--- a/src/web.ts
+++ b/src/web.ts
@@ -57,7 +57,7 @@ declare global {
 
 export class FacebookLoginWeb extends WebPlugin implements FacebookLoginPlugin {
   async initialize(options: Partial<FacebookConfiguration>): Promise<void> {
-    const defaultOptions = { version: 'v17.0' };
+    const defaultOptions = { version: 'v26.0' };
     await this.loadScript(options.locale);
     return FB.init({ ...defaultOptions, ...options });
   }


### PR DESCRIPTION
## Summary

- update the default Facebook Android SDK from 18.1.3 to 18.3.0
- update the Facebook iOS SDK requirement to 18.1 for CocoaPods and 18.1.0 for Swift Package Manager
- update the default Web Graph API version from v17.0 to v26.0
- document the resolved native dependency ranges and Web default

## Verification

- `npm run build`
- Android Gradle build, unit tests, and lint
- Swift Package Manager device build (resolved Facebook iOS SDK 18.1.0)
- `pod lib lint CapacitorCommunityFacebookLogin.podspec --allow-warnings --platforms=ios`
- Android 16 physical device: login, current access token, profile, and `logEvent`
- iPhone 15 Pro Max physical device: login and `logEvent` completion
- Web HTTPS demo with Graph API v17.0 and v26.0: login, logout/re-login, current access token, profile, and `logEvent`
- `git diff --check`